### PR TITLE
UIA mapping for aria-placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -3387,7 +3387,7 @@ var mappingTableLabels = {
 					<span class="property">Object Attribute: <code>placeholder-text:&lt;value&gt;</code></span>
 				</td>
 				<td class="attr-uia">
-					<span class="property">Property: <code>AriaProperties.placeholder</code>: <code>&lt;value&gt;</code></span>
+					<span class="property">Property: <code>HelpText</code>: <code>&lt;value&gt;</code></span>
 				</td>
 				<td class="attr-atk">
 					<span class="property">Object Attribute: <code>placeholder-text:&lt;value&gt;</code></span>


### PR DESCRIPTION
In the last release we made a change to map placeholder attribute and aria-placeholder to the UIA HelpText property (https://msdn.microsoft.com/en-us/library/dd757479(v=vs.85).aspx). This change reflects that.

Note: AriaProperties gets automatically populated with ALL aria-* properties, which is very easy way to "map" something, when there is no better alternative. Now that we found alternative for placeholder - we can actually specify it properly.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/pull/6.html" title="Last updated on May 2, 2018, 5:39 PM GMT (7e02cca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/6/13927b0...7e02cca.html" title="Last updated on May 2, 2018, 5:39 PM GMT (7e02cca)">Diff</a>