### PR TITLE
update widget values links

### DIFF
--- a/index.html
+++ b/index.html
@@ -3605,38 +3605,38 @@ var mappingTableLabels = {
 				<th><a class="property-reference" href="#aria-valuemax"><code>aria-valuemax</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="method">Method: <code>IAccessibleValue::maximumValue()</code>: <code>&lt;value&gt;</code></span><br />
-					<span class="seealso">See also: <a href="#mapping_additional_widget-value">Widget values</a></span>
+					<span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
 				</td>
 				<td class="attr-uia">
 					<span class="property">Property: <code>RangeValue.Maximum</code>: <code>&lt;value&gt;</code></span><br />
-					<span class="seealso">See also: <a href="#mapping_additional_widget-value">Widget values</a></span>
+					<span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
 				</td>
 				<td class="attr-atk">
 					<span class="method">Method: <code>atk_value_get_maximum_value()</code>: <code>&lt;value&gt;</code></span><br />
-					<span class="seealso">See also: <a href="#mapping_additional_widget-value">Widget values</a></span>
+					<span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
 				</td>
 				<td class="attr-axapi">
 					<span class="property">Property: <code>AXMaxValue</code>: <code>&lt;value&gt;</code></span><br />
-					<span class="seealso">See also: <a href="#mapping_additional_widget-value">Widget values</a></span>
+					<span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
 				</td>
 			</tr>
 			<tr id="ariaValueMin">
 				<th><a class="property-reference" href="#aria-valuemin"><code>aria-valuemin</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="method">Method: <code>IAccessibleValue::minimumValue()</code>: <code>&lt;value&gt;</code></span><br />
-					<span class="seealso">See also: <a href="#mapping_additional_widget-value">Widget values</a></span>
+					<span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
 				</td>
 				<td class="attr-uia">
 					<span class="property">Property: <code>RangeValue.Minimum</code>: <code>&lt;value&gt;</code></span><br />
-					<span class="seealso">See also: <a href="#mapping_additional_widget-value">Widget values</a></span>
+					<span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
 				</td>
 				<td class="attr-atk">
 					<span class="method">Method: <code>atk_value_get_minimum_value()</code>: <code>&lt;value&gt;</code></span><br />
-					<span class="seealso">See also: <a href="#mapping_additional_widget-value">Widget values</a></span>
+					<span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
 				</td>
 				<td class="attr-axapi">
 					<span class="property">Property: <code>AXMinValue</code>: <code>&lt;value&gt;</code></span><br />
-					<span class="seealso">See also: <a href="#mapping_additional_widget-value">Widget values</a></span>
+					<span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
 				</td>
 			</tr>
 			<tr id="ariaValueNow">
@@ -3644,19 +3644,19 @@ var mappingTableLabels = {
 				<td class="attr-msaa-ia2">
 					<span class="method">Method: <code>IAccessibleValue::currentValue()</code>: <code>&lt;value&gt;</code></span><br />
 					<span class="method">Method: <code>IAccessible::get_accValue()</code>: <code>&lt;value&gt;</code> if <code>aria-valuetext</code> is not defined</span><br />
-					<span class="seealso">See also: <a href="#mapping_additional_widget-value">Widget values</a></span>
+					<span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
 				</td>
 				<td class="attr-uia">
 					<span class="property">Property: <code>RangeValue.Value</code>: <code>&lt;value&gt;</code></span><br />
-					<span class="seealso">See also: <a href="#mapping_additional_widget-value">Widget values</a></span>
+					<span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
 				</td>
 				<td class="attr-atk">
 					<span class="method">Method: <code>atk_value_get_current_value()</code>: <code>&lt;value&gt;</code></span><br />
-					<span class="seealso">See also: <a href="#mapping_additional_widget-value">Widget values</a></span>
+					<span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
 				</td>
 				<td class="attr-axapi">
 					<span class="property">Property: <code>AXValue</code>: <code>&lt;value&gt;</code></span><br />
-					<span class="seealso">See also: <a href="#mapping_additional_widget-value">Widget values</a></span>
+					<span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
 				</td>
 			</tr>
 			<tr id="ariaValueText">
@@ -3664,19 +3664,19 @@ var mappingTableLabels = {
 				<td class="attr-msaa-ia2">
 					<span class="method">Method: <code>IAccessible::get_accValue()</code>: <code>&lt;value&gt;</code></span><br />
 					<span class="property">Object Attribute: <code>valuetext:&lt;value&gt;</code></span><br />
-					<span class="seealso">See also: <a href="#mapping_additional_widget-value">Widget values</a></span>
+					<span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
 				</td>
 				<td class="attr-uia">
 					<span class="property">Property: <code>Value.Value</code>: <code>&lt;value&gt;</code></span><br />
-					<span class="seealso">See also: <a href="#mapping_additional_widget-value">Widget values</a></span>
+					<span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
 				</td>
 				<td class="attr-atk">
 					<span class="property">Object Attribute: <code>valuetext:&lt;value&gt;</code></span><br />
-					<span class="seealso">See also: <a href="#mapping_additional_widget-value">Widget values</a></span>
+					<span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
 				</td>
 				<td class="attr-axapi">
 					<span class="property">Property: <code>AXValueDescription</code>: <code>&lt;value&gt;</code></span><br />
-					<span class="seealso">See also: <a href="#mapping_additional_widget-value">Widget values</a></span>
+					<span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
 				</td>
 			</tr>
               </tbody>


### PR DESCRIPTION
eecb5af7e130134337d6a101a3dbac7db4780ced moved the widget values section
to the ARIA spec. Based on the commit comment, I'm updating links to
that section as best as I can figure out.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/pull/40.html" title="Last updated on Dec 18, 2018, 6:33 PM UTC (5a83e14)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/40/f8c600c...5a83e14.html" title="Last updated on Dec 18, 2018, 6:33 PM UTC (5a83e14)">Diff</a>