### PR TITLE
Remove line-height

### DIFF
--- a/css/core-aam.css
+++ b/css/core-aam.css
@@ -1,7 +1,3 @@
-* { 
-	/* add default line-height so different fonts don't affect the rhythm of line-box height */
-	line-height:1.2; /* [sic] unitless multiplier, not EM size */
-}
 ol{ list-style:decimal; }
 ol ol{ list-style:upper-alpha; }
 ol ol ol{ list-style:lower-roman; }
@@ -49,7 +45,6 @@ html pre { /* more specific selector than the default W3C style sheet */
 	margin:1em 0;
 	padding:0.5em 0.8em;
 	font-size:0.75em; /* text in blocks code blocks looked too big now that font is back to normal size */
-	line-height:1.4; /* [sic] unitless multiplier, not EM size */
 }
 pre .tag, code .tag, code.tag{
 	color:#00c; /* blue */
@@ -173,7 +168,7 @@ dl.compact dd {
 	margin-top: -2.5em;
 	/*color:#333 !important;*/
 }
-.permalink a, .permalink a:link, .permalink a:visited, .permalink a:hover, .permalink a:focus, .permalink a:active 
+.permalink a, .permalink a:link, .permalink a:visited, .permalink a:hover, .permalink a:focus, .permalink a:active
 {
 	background:transparent !important;
 	text-decoration:none;


### PR DESCRIPTION
Remove Line Height from core-aam.css to make spec easier to read. (side-note why do we have a specific core-aam CSS)