### PR TITLE
Use ROLE_SYSTEM_BUTTONMENU only if aria-haspopup=true or menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -472,7 +472,7 @@ var mappingTableLabels = {
 					</td>
 				</tr>
 				<tr id="role-map-button">
-					<th><a class="role-reference" href="#button"><code>button</code></a> with default values for <a class="property-reference" href="#aria-pressed"><code>aria-pressed</code></a> and <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a></th>
+					<th><a class="role-reference" href="#button"><code>button</code></a> with default value for <a class="property-reference" href="#aria-pressed"><code>aria-pressed</code></a> and a value other than <code>true</code> or <code>menu</code> for <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_PUSHBUTTON</code></span>
 					</td>
@@ -488,7 +488,7 @@ var mappingTableLabels = {
 					</td>
 				</tr>
 				<tr id="role-map-button-haspopup">
-					<th><a class="role-reference" href="#button"><code>button</code></a> with non-<code>false</code> value for <code>aria-haspopup</code></th>
+					<th><a class="role-reference" href="#button"><code>button</code></a> with <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a> set to <code>true</code> or <code>menu</code></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_BUTTONMENU</code></span>
 					</td>

--- a/index.html
+++ b/index.html
@@ -472,7 +472,7 @@ var mappingTableLabels = {
 					</td>
 				</tr>
 				<tr id="role-map-button">
-					<th><a class="role-reference" href="#button"><code>button</code></a> with default value for <a class="property-reference" href="#aria-pressed"><code>aria-pressed</code></a> and a value other than <code>true</code> or <code>menu</code> for <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a></th>
+					<th><a class="role-reference" href="#button"><code>button</code></a> with undefined value for <a class="property-reference" href="#aria-pressed"><code>aria-pressed</code></a> and a value other than <code>true</code> or <code>menu</code> for <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_PUSHBUTTON</code></span>
 					</td>


### PR DESCRIPTION
Fixes #51 as suggested in https://github.com/w3c/core-aam/issues/51#issuecomment-645673241 so that the mappings match the ARIA spec for button with aria-haspopup.
Note that in the following, only the 2 descriptions of when to map have changed... not the mappings themselves.
(i.e. I am only listing the mappings below under their new descriptions for reviewing convenience).

- button with default value for aria-pressed and a value other than true or menu for aria-haspopup
    - MSAA: ROLE_SYSTEM_PUSHBUTTON
    - UIA: Button
    - ATK: ROLE_PUSH_BUTTON
    - AX: AXButton
- button with aria-haspopup set to true or menu
    - MSAA: ROLE_SYSTEM_BUTTONMENU
    - UIA: Button
    - ATK: ROLE_PUSH_BUTTON
    - AX: AXPopUpButton

Review notes: For some reason, pr-preview doesn't generate the mapping tables, so the Preview and Diff links below are useless.
So here's a couple of raw githack preview links that work:
- [role-map-button](https://raw.githack.com/w3c/core-aam/car/issue51/index.html#role-map-button)
- [role-map-button-haspopup](https://raw.githack.com/w3c/core-aam/car/issue51/index.html#role-map-button-haspopup)

Or this can be reviewed in the Files changed tab in github. It's a 2-line change.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/pull/86.html" title="Last updated on Jan 20, 2021, 11:03 PM UTC (568aa70)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/86/ca34043...568aa70.html" title="Last updated on Jan 20, 2021, 11:03 PM UTC (568aa70)">Diff</a>