### PR TITLE
editorial: export terms so other specs can use them

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,15 +288,15 @@ var mappingTableLabels = {
   <div>
 		<p>While some terms are defined in place, the following definitions are used throughout this document. </p>
 		<dl class="termlist">
-			<dt><dfn>Accessibility Subtree</dfn></dt>
+			<dt><dfn data-export="">Accessibility Subtree</dfn></dt>
 			<dd>
 				<p>An [=accessible object=] in the <a>accessibility tree</a> and its descendants in that tree. It does not include objects which have relationships other than parent-child in that tree. For example, it does not include objects linked via <pref>aria-flowto</pref> unless those objects are also descendants in the <a>accessibility tree</a>.</p>
 			</dd>
-			<dt><dfn>Accessibility Tree</dfn></dt>
+			<dt><dfn data-export="">Accessibility Tree</dfn></dt>
 			<dd>
 				<p>Tree of <a class="termref" data-lt="accessible object">accessible objects</a> that represents the structure of the user interface (UI). Each node in the accessibility tree represents an element in the <abbr title="user interface">UI</abbr> as exposed through the <a>accessibility <abbr title="Application Programming Interface">API</abbr></a>; for example, a push button, a check box, or container.</p>
 			</dd>
-			<dt><dfn>Activation behavior</dfn></dt>
+			<dt><dfn data-export="">Activation behavior</dfn></dt>
 			<dd>
 				<p>The action taken when an <a>event</a>, typically initiated by users through an input device, causes an element to fulfill a defined role. The role may be defined for that element by the host language, or by author-defined variables, or both. The role for any given element may be a generic action, or may be unique to that element. For example, the activation behavior of an <abbr title="Hypertext Markup Language">HTML</abbr> or <abbr title="Scalable Vector Graphics">SVG</abbr> <code>&lt;a&gt;</code> element shall be to cause the user agent to traverse the link specified in the <code>href</code> attribute, with the further optional parameter of specifying the browsing context for the traversal (such as the current window or tab, a named window, or a new window); the activation behavior of an <abbr title="Hypertext Markup Language">HTML</abbr> <code>&lt;input&gt;</code> element with the <code>type</code> attribute value <code>submit</code> shall be to send the values of the form elements to an author-defined <abbr title="Internationalized Resource Identifiers">IRI</abbr> by the author-defined <abbr title="Hypertext Transfer Protocol">HTTP</abbr> method.</p>
 			</dd>


### PR DESCRIPTION
add exports for the terms


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/pull/93.html" title="Last updated on Apr 24, 2021, 12:10 AM UTC (e2621aa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/93/5890bb3...e2621aa.html" title="Last updated on Apr 24, 2021, 12:10 AM UTC (e2621aa)">Diff</a>