### PR TITLE
Fix UIA TablePattern and GridPattern mappings

### DIFF
--- a/index.html
+++ b/index.html
@@ -553,6 +553,7 @@ var mappingTableLabels = {
 					<td class="role-uia">
 						<span class="property">Control Type: <code>DataItem</code></span><br />
 						<span class="property">Localized Control Type: <code>cell</code></span><br />
+						<span class="property">Control Pattern: <code>GridItem</code></span><br />
 						<span class="property">Control Pattern: <code>TableItem</code></span>
 					</td>
 					<td class="role-atk">

--- a/index.html
+++ b/index.html
@@ -610,7 +610,9 @@ var mappingTableLabels = {
 						<span class="property">Interface: <code>IAccessibleTableCell</code></span>
 					</td>
 					<td class="role-uia">
-						<span class="property">Control Type: <code>HeaderItem</code></span>
+						<span class="property">Control Type: <code>DataItem</code></span><br />
+						<span class="property">Control Pattern: <code>GridItem</code></span><br />
+						<span class="property">Control Pattern: <code>TableItem</code></span>
 					</td>
 					<td class="role-atk">
 						<span class="property">Role: <code>ROLE_COLUMN_HEADER</code></span><br />
@@ -892,6 +894,8 @@ var mappingTableLabels = {
 					</td>
 					<td class="role-uia">
 						<span class="property">Control Type: <code>DataGrid</code></span><br />
+						<span class="property">Control Pattern: <code>Grid</code></span><br />
+						<span class="property">Control Pattern: <code>Table</code></span><br />
 						<span class="property">Control Pattern: <code>Selection</code></span>
 					</td>
 					<td class="role-atk">
@@ -919,6 +923,8 @@ var mappingTableLabels = {
 						<span class="property">Control Type: <code>DataItem</code></span><br />
 						<span class="property">Localized Control Type: <code>gridcell</code></span><br />
 						<span class="property">Control Pattern: <code>SelectionItem</code></span><br />
+						<span class="property">Control Pattern: <code>GridItem</code></span><br />
+						<span class="property">Control Pattern: <code>TableItem</code></span><br />
 						<span class="property">SelectionItem.SelectionContainer: the containing <code>grid</code></span>
 					</td>
 					<td class="role-atk">

--- a/index.html
+++ b/index.html
@@ -552,7 +552,7 @@ var mappingTableLabels = {
 					</td>
 					<td class="role-uia">
 						<span class="property">Control Type: <code>DataItem</code></span><br />
-						<span class="property">Localized Control Type: <code>cell</code></span><br />
+						<span class="property">Localized Control Type: <code>item</code></span><br />
 						<span class="property">Control Pattern: <code>GridItem</code></span><br />
 						<span class="property">Control Pattern: <code>TableItem</code></span>
 					</td>
@@ -612,6 +612,7 @@ var mappingTableLabels = {
 					</td>
 					<td class="role-uia">
 						<span class="property">Control Type: <code>DataItem</code></span><br />
+						<span class="property">Localized Control Type: <code>column header</code></span><br />
 						<span class="property">Control Pattern: <code>GridItem</code></span><br />
 						<span class="property">Control Pattern: <code>TableItem</code></span>
 					</td>
@@ -922,7 +923,7 @@ var mappingTableLabels = {
 					</td>
 					<td class="role-uia">
 						<span class="property">Control Type: <code>DataItem</code></span><br />
-						<span class="property">Localized Control Type: <code>gridcell</code></span><br />
+						<span class="property">Localized Control Type: <code>item</code></span><br />
 						<span class="property">Control Pattern: <code>SelectionItem</code></span><br />
 						<span class="property">Control Pattern: <code>GridItem</code></span><br />
 						<span class="property">Control Pattern: <code>TableItem</code></span><br />


### PR DESCRIPTION
Some parts of the current mappings for grid, cell, gridcell, and columnheader in UIA didn't match the UIA documentation or practical implementation.

UIA expects both the `TablePattern` and `GridPattern` implemented for both `role="table"` and `role="grid"` (TablePattern is required for virtual cursor table navigation, and GridPattern is required by TablePattern). More info: https://docs.microsoft.com/en-us/windows/win32/api/uiautomationcore/nn-uiautomationcore-itableprovider and https://docs.microsoft.com/en-us/windows/win32/winauto/uiauto-implementingtableitem

The changes in this PR match the current UIA implementation in Edge (verified in v92 and v94).

cc/ @dlibby-