### PR TITLE
Fix automatic exporting and add missing IDs back to mapping tables

### DIFF
--- a/common/script/mapping-tables.js
+++ b/common/script/mapping-tables.js
@@ -14,7 +14,7 @@ function queryAll(selector, context) {
 }
 
 function getElementIndex(el) {
-  var i = 0;
+  var i = 1;
   while ((el = el.previousElementSibling)) {
     i++;
   }

--- a/common/script/mapping-tables.js
+++ b/common/script/mapping-tables.js
@@ -29,6 +29,7 @@ function viewAsSingleTable(mappingTableInfo) {
   queryAll('summary', mappingTableInfo.detailsContainer).forEach(function (
     summary
   ) {
+    summary.dataset['id'] = summary.id;
     summary.removeAttribute('id');
   });
   showElement(mappingTableInfo.tableContainer);
@@ -38,6 +39,7 @@ function viewAsSingleTable(mappingTableInfo) {
     tr
   ) {
     tr.id = tr.dataset['id'];
+    tr.removeAttribute('data-id');
   });
 }
 
@@ -47,6 +49,7 @@ function viewAsDetails(mappingTableInfo) {
   queryAll('tbody tr', mappingTableInfo.tableContainer).forEach(function (
     tr
   ) {
+    tr.dataset['id'] = tr.id;
     tr.removeAttribute('id');
   });
   showElement(mappingTableInfo.detailsContainer);
@@ -55,6 +58,7 @@ function viewAsDetails(mappingTableInfo) {
     summary
   ) {
     summary.id = summary.dataset['id'];
+    summary.removeAttribute('data-id');
   });
 }
 
@@ -93,7 +97,6 @@ function mappingTables() {
     viewSwitch.className = 'switch-view removeOnSave';
     viewSwitch.innerHTML = mappingTableLabels.viewByTable;
     viewSwitch.addEventListener('click', function () {
-      // array to store summary/tr @ids
       // if current view is details/summary
       if (tableInfo.detailsContainer.style.display !== 'none') {
         viewAsSingleTable(tableInfo);
@@ -151,7 +154,7 @@ function mappingTables() {
       var details = document.createElement('details');
       details.className = 'map';
 
-      var detailsHTML = '<summary id="' + id + '" data-id="' + id + '">' + summary;
+      var detailsHTML = '<summary id="' + id + '">' + summary;
 
       // if attributes mapping table, append relevant elements to summary
       if (tableInfo.table.classList.contains('attributes')) {

--- a/index.html
+++ b/index.html
@@ -359,7 +359,7 @@ var mappingTableLabels = {
 				</tr>
 			</thead>
 			<tbody>
-				<tr id="role-map-alert">
+				<tr data-id="role-map-alert">
 					<th><a class="role-reference" href="#alert"><code>alert</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_ALERT</code></span><br />
@@ -381,7 +381,7 @@ var mappingTableLabels = {
 						<span class="event">Event: The user agent SHOULD fire a system alert <a class="termref">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span>
 					</td>
 				</tr>
-				<tr id="role-map-alertdialog">
+				<tr data-id="role-map-alertdialog">
 					<th><a class="role-reference" href="#alertdialog"><code>alertdialog</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_DIALOG</code></span><br />
@@ -402,7 +402,7 @@ var mappingTableLabels = {
 						<span class="event">Event: The user agent SHOULD fire a system alert <a class="termref">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span>
 					</td>
 				</tr>
-				<tr id="role-map-application">
+				<tr data-id="role-map-application">
 					<th><a class="role-reference" href="#application"><code>application</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_APPLICATION</code></span>
@@ -419,7 +419,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXWebApplication</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-article">
+				<tr data-id="role-map-article">
 					<th><a class="role-reference" href="#article"><code>article</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_DOCUMENT</code></span><br />
@@ -439,7 +439,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXDocumentArticle</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-banner">
+				<tr data-id="role-map-banner">
 					<th><a class="role-reference" href="#banner"><code>banner</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br />
@@ -460,7 +460,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXLandmarkBanner</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-blockquote">
+				<tr data-id="role-map-blockquote">
 					<th><a class="role-reference" href="#blockquote"><code>blockquote</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br />
@@ -478,7 +478,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-button">
+				<tr data-id="role-map-button">
 					<th><a class="role-reference" href="#button"><code>button</code></a> with default values for <a class="property-reference" href="#aria-pressed"><code>aria-pressed</code></a> and <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_PUSHBUTTON</code></span>
@@ -494,7 +494,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-button-haspopup">
+				<tr data-id="role-map-button-haspopup">
 					<th><a class="role-reference" href="#button"><code>button</code></a> with non-<code>false</code> value for <code>aria-haspopup</code></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_BUTTONMENU</code></span>
@@ -510,7 +510,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-button-pressed">
+				<tr data-id="role-map-button-pressed">
 					<th><a class="role-reference" href="#button"><code>button</code></a> with defined value for <a class="property-reference" href="#aria-pressed"><code>aria-pressed</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_PUSHBUTTON</code></span><br />
@@ -527,7 +527,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXToggle</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-caption">
+				<tr data-id="role-map-caption">
 					<th><a class="role-reference" href="#caption"><code>caption</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_TEXT</code></span><br />
@@ -544,7 +544,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-cell">
+				<tr data-id="role-map-cell">
 					<th><a class="role-reference" href="#cell"><code>cell</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_CELL</code></span><br />
@@ -565,7 +565,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-checkbox">
+				<tr data-id="role-map-checkbox">
 					<th><a class="role-reference" href="#checkbox"><code>checkbox</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_CHECKBUTTON</code></span><br />
@@ -585,7 +585,7 @@ var mappingTableLabels = {
 						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
 					</td>
 				</tr>
-				<tr id="role-map-code">
+				<tr data-id="role-map-code">
 					<th><a class="role-reference" href="#code"><code>code</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span><br />
@@ -604,7 +604,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXCodeStyleGroup</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-columnheader">
+				<tr data-id="role-map-columnheader">
 					<th><a class="role-reference" href="#columnheader"><code>columnheader</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_COLUMNHEADER</code></span><br />
@@ -625,7 +625,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-combobox">
+				<tr data-id="role-map-combobox">
 					<th><a class="role-reference" href="#combobox"><code>combobox</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_COMBOBOX</code></span><br />
@@ -645,7 +645,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-comment">
+				<tr data-id="role-map-comment">
 					<th><a class="role-reference" href="#comment"><code>comment</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_COMMENT</code></span><br />
@@ -663,7 +663,7 @@ var mappingTableLabels = {
 						<span class="property">AXRole: <code>AXGroup</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-complementary">
+				<tr data-id="role-map-complementary">
 					<th><a class="role-reference" href="#complementary"><code>complementary</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br />
@@ -684,7 +684,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXLandmarkComplementary</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-contentinfo">
+				<tr data-id="role-map-contentinfo">
 					<th><a class="role-reference" href="#contentinfo"><code>contentinfo</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br />
@@ -705,7 +705,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXLandmarkContentInfo</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-definition">
+				<tr data-id="role-map-definition">
 					<th><a class="role-reference" href="#definition"><code>definition</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Object Attribute: <code>xml-roles:definition</code></span>
@@ -723,7 +723,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXDefinition</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-deletion">
+				<tr data-id="role-map-deletion">
 					<th><a class="role-reference" href="#deletion"><code>deletion</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_CONTENT_DELETION</code></span>
@@ -741,7 +741,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXDeleteStyleGroup</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-dialog">
+				<tr data-id="role-map-dialog">
 					<th><a class="role-reference" href="#dialog"><code>dialog</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_DIALOG</code></span>
@@ -758,7 +758,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXApplicationDialog</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-directory">
+				<tr data-id="role-map-directory">
 					<th><a class="role-reference" href="#directory"><code>directory</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_LIST</code></span>
@@ -774,7 +774,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXContentList</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-document">
+				<tr data-id="role-map-document">
 					<th><a class="role-reference" href="#document"><code>document</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_DOCUMENT</code></span><br />
@@ -791,7 +791,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXDocument</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-emphasis">
+				<tr data-id="role-map-emphasis">
 					<th><a class="role-reference" href="#emphasis"><code>emphasis</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span><br />
@@ -810,7 +810,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXEmphasisStyleGroup</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-feed">
+				<tr data-id="role-map-feed">
 					<th><a class="role-reference" href="#feed"><code>feed</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br />
@@ -829,7 +829,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXApplicationGroup</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-figure">
+				<tr data-id="role-map-figure">
 					<th><a class="role-reference" href="#figure"><code>figure</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br />
@@ -848,7 +848,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-form">
+				<tr data-id="role-map-form">
 					<th><a class="role-reference" href="#form"><code>form</code></a> with an accessible name</th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_FORM</code></span><br />
@@ -868,7 +868,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-form-nameless">
+				<tr data-id="role-map-form-nameless">
 					<th><a class="role-reference" href="#form"><code>form</code></a> without an accessible name</th>
 					<td class="role-msaa-ia2">
 						<span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
@@ -883,7 +883,7 @@ var mappingTableLabels = {
 						<span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
 					</td>
 				</tr>
-				<tr id="role-map-generic">
+				<tr data-id="role-map-generic">
 					<th><a class="role-reference" href="#generic"><code>generic</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br />
@@ -900,7 +900,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-grid">
+				<tr data-id="role-map-grid">
 					<th><a class="role-reference" href="#grid"><code>grid</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_TABLE</code></span><br />
@@ -930,7 +930,7 @@ var mappingTableLabels = {
 						<span class="property">AXRowHeaderUIElements: a list of pointers to the rowheader elements</span>
 					</td>
 				</tr>
-				<tr id="role-map-gridcell">
+				<tr data-id="role-map-gridcell">
 					<th><a class="role-reference" href="#gridcell"><code>gridcell</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_CELL</code></span><br />
@@ -953,7 +953,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-group">
+				<tr data-id="role-map-group">
 					<th><a class="role-reference" href="#group"><code>group</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span>
@@ -969,7 +969,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXApplicationGroup</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-heading">
+				<tr data-id="role-map-heading">
 					<th><a class="role-reference" href="#heading"><code>heading</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_HEADING</code></span><br />
@@ -987,7 +987,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-img">
+				<tr data-id="role-map-img">
 					<th><a class="role-reference" href="#img"><code>img</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_GRAPHIC</code></span><br />
@@ -1005,7 +1005,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-insertion">
+				<tr data-id="role-map-insertion">
 					<th><a class="role-reference" href="#insertion"><code>insertion</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_CONTENT_INSERTION</code></span>
@@ -1023,7 +1023,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXInsertStyleGroup</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-label">
+				<tr data-id="role-map-label">
 					<th><a class="role-reference" href="#label"><code>label</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_STATICTEXT</code></span><br />
@@ -1044,7 +1044,7 @@ var mappingTableLabels = {
 						<span class="seealso">See also: <a href="#ariaLabelledBy">aria-labelledby</a> regarding exposure of the labeled widget.</span>
 					</td>
 				</tr>
-				<tr id="role-map-legend">
+				<tr data-id="role-map-legend">
 					<th><a class="role-reference" href="#legend"><code>legend</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_STATICTEXT</code></span><br />
@@ -1065,7 +1065,7 @@ var mappingTableLabels = {
 						<span class="seealso">See also: <a href="#ariaLabelledBy">aria-labelledby</a> regarding exposure of the labeled group.</span>
 					</td>
 				</tr>
-				<tr id="role-map-link">
+				<tr data-id="role-map-link">
 					<th><a class="role-reference" href="#link"><code>link</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_LINK</code></span><br />
@@ -1086,7 +1086,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-list">
+				<tr data-id="role-map-list">
 					<th><a class="role-reference" href="#list"><code>list</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_LIST</code></span><br />
@@ -1103,7 +1103,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXContentList</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-listbox">
+				<tr data-id="role-map-listbox">
 					<th><a class="role-reference" href="#listbox"><code>listbox</code></a> not owned by or child of <code>combobox</code></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_LIST</code></span><br />
@@ -1124,7 +1124,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-listbox-in-combobox">
+				<tr data-id="role-map-listbox-in-combobox">
 					<th><a class="role-reference" href="#listbox"><code>listbox</code></a> owned by or child of <code>combobox</code></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_LIST</code></span><br />
@@ -1145,7 +1145,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-listitem">
+				<tr data-id="role-map-listitem">
 					<th><a class="role-reference" href="#listitem"><code>listitem</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_LISTITEM</code></span><br />
@@ -1164,7 +1164,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-log">
+				<tr data-id="role-map-log">
 					<th><a class="role-reference" href="#log"><code>log</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Object Attribute: <code>xml-roles:log</code></span><br />
@@ -1189,7 +1189,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXApplicationLog</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-main">
+				<tr data-id="role-map-main">
 					<th><a class="role-reference" href="#main"><code>main</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br />
@@ -1209,7 +1209,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXLandmarkMain</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-mark">
+				<tr data-id="role-map-mark">
 					<th><a class="role-reference" href="#mark"><code>mark</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br />
@@ -1227,7 +1227,7 @@ var mappingTableLabels = {
 						<span class="property">AXRole: <code>AXGroup</code></span>
 					</td>
 				</tr>
-				<tr id="role-map-marquee">
+				<tr data-id="role-map-marquee">
 					<th><a class="role-reference" href="#marquee"><code>marquee</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_ANIMATION</code></span><br />
@@ -1250,7 +1250,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXApplicationMarquee</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-math">
+				<tr data-id="role-map-math">
 					<th><a class="role-reference" href="#math"><code>math</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_EQUATION</code></span>
@@ -1267,7 +1267,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXDocumentMath</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-menu">
+				<tr data-id="role-map-menu">
 					<th><a class="role-reference" href="#menu"><code>menu</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_MENUPOPUP</code></span><br />
@@ -1287,7 +1287,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-menubar">
+				<tr data-id="role-map-menubar">
 					<th><a class="role-reference" href="#menubar"><code>menubar</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_MENUBAR</code></span><br />
@@ -1307,7 +1307,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-menuitem">
+				<tr data-id="role-map-menuitem">
 					<th><a class="role-reference" href="#menuitem"><code>menuitem</code></a> not owned by or child of <code>group</code></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_MENUITEM</code></span>
@@ -1323,7 +1323,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-menuitem-group-parent">
+				<tr data-id="role-map-menuitem-group-parent">
 					<th><a class="role-reference" href="#menuitem"><code>menuitem</code></a> owned by or child of <code>group</code></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_MENUITEM</code></span>
@@ -1339,7 +1339,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-menuitemcheckbox">
+				<tr data-id="role-map-menuitemcheckbox">
 					<th><a class="role-reference" href="#menuitemcheckbox"><code>menuitemcheckbox</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_CHECKBUTTON</code> or <code>ROLE_SYSTEM_MENUITEM</code></span><br />
@@ -1361,7 +1361,7 @@ var mappingTableLabels = {
 						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
 					</td>
 				</tr>
-				<tr id="role-map-menuitemradio">
+				<tr data-id="role-map-menuitemradio">
 					<th><a class="role-reference" href="#menuitemradio"><code>menuitemradio</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_RADIOBUTTON</code> or <code>ROLE_SYSTEM_MENUITEM</code></span><br />
@@ -1384,7 +1384,7 @@ var mappingTableLabels = {
 						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
 					</td>
 				</tr>
-				<tr id="role-map-meter">
+				<tr data-id="role-map-meter">
 					<th><a class="role-reference" href="#meter"><code>meter</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_LEVEL_BAR</code></span><br />
@@ -1405,7 +1405,7 @@ var mappingTableLabels = {
 					</td>
 				</tr>
 
-				<tr id="role-map-navigation">
+				<tr data-id="role-map-navigation">
 					<th><a class="role-reference" href="#navigation"><code>navigation</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br />
@@ -1425,7 +1425,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXLandmarkNavigation</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-none">
+				<tr data-id="role-map-none">
 				<th><a class="role-reference" href="#none"><code>none</code></a></th>
 					<td class="role-msaa-ia2">
 						<p>For objects that have required owned descendants (e.g., a grid owns gridcells, a list owns listitems), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>IA2_ROLE_TEXT_FRAME</code>.  <a class="termref">User agents</a> SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
@@ -1440,7 +1440,7 @@ var mappingTableLabels = {
 						<p>For objects that have required owned descendants (e.g., a grid owns gridcells, a list owns listitems), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>AXGroup</code>.  <a class="termref">User agents</a> SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
 					</td>
 				</tr>
-				<tr id="role-map-note">
+				<tr data-id="role-map-note">
 					<th><a class="role-reference" href="#note"><code>note</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_NOTE</code></span>
@@ -1457,7 +1457,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXDocumentNote</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-option">
+				<tr data-id="role-map-option">
 					<th><a class="role-reference" href="#option"><code>option</code></a> not inside <code>combobox</code></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_LISTITEM</code></span><br />
@@ -1478,7 +1478,7 @@ var mappingTableLabels = {
 						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
 					</td>
 				</tr>
-				<tr id="role-map-option-in-combobox">
+				<tr data-id="role-map-option-in-combobox">
 					<th><a class="role-reference" href="#option"><code>option</code></a> inside <code>combobox</code></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_LISTITEM</code></span><br />
@@ -1499,7 +1499,7 @@ var mappingTableLabels = {
 						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
 					</td>
 				</tr>
-				<tr id="role-map-paragraph">
+				<tr data-id="role-map-paragraph">
 					<th><a class="role-reference" href="#paragraph"><code>paragraph</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_TEXT</code></span><br />
@@ -1516,7 +1516,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-presentation">
+				<tr data-id="role-map-presentation">
 					<th><a class="role-reference" href="#presentation"><code>presentation</code></a></th>
 					<td class="role-msaa-ia2">
 						<p>For objects that have required owned descendants (e.g., a grid owns gridcells, a list owns listitems), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>IA2_ROLE_TEXT_FRAME</code>.  <a class="termref">User agents</a> SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
@@ -1531,7 +1531,7 @@ var mappingTableLabels = {
 						<p>For objects that have required owned descendants (e.g., a grid owns gridcells, a list owns listitems), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>AXGroup</code>.  <a class="termref">User agents</a> SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
 					</td>
 				</tr>
-				<tr id="role-map-progressbar">
+				<tr data-id="role-map-progressbar">
 					<th><a class="role-reference" href="#progressbar"><code>progressbar</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_PROGRESSBAR</code></span><br />
@@ -1552,7 +1552,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-radio">
+				<tr data-id="role-map-radio">
 					<th><a class="role-reference" href="#radio"><code>radio</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_RADIOBUTTON</code></span><br />
@@ -1574,7 +1574,7 @@ var mappingTableLabels = {
 						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
 					</td>
 				</tr>
-				<tr id="role-map-radiogroup">
+				<tr data-id="role-map-radiogroup">
 					<th><a class="role-reference" href="#radiogroup"><code>radiogroup</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span>
@@ -1590,7 +1590,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-region">
+				<tr data-id="role-map-region">
 					<th><a class="role-reference" href="#region"><code>region</code></a> with an accessible name</th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br />
@@ -1611,7 +1611,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXLandmarkRegion</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-region-nameless">
+				<tr data-id="role-map-region-nameless">
 					<th><a class="role-reference" href="#region"><code>region</code></a> without an accessible name</th>
 					<td class="role-msaa-ia2">
 						<span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
@@ -1626,7 +1626,7 @@ var mappingTableLabels = {
 						<span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
 					</td>
 				</tr>
-				<tr id="role-map-row">
+				<tr data-id="role-map-row">
 					<th><a class="role-reference" href="#row"><code>row</code></a> not inside <code>treegrid</code></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_ROW</code></span>
@@ -1644,7 +1644,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-row-in-treegrid">
+				<tr data-id="role-map-row-in-treegrid">
 					<th><a class="role-reference" href="#row"><code>row</code></a> inside <code>treegrid</code></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_OUTLINEITEM</code></span>
@@ -1662,7 +1662,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-rowgroup">
+				<tr data-id="role-map-rowgroup">
 					<th><a class="role-reference" href="#rowgroup"><code>rowgroup</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span>
@@ -1677,7 +1677,7 @@ var mappingTableLabels = {
 						<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
 					</td>
 				</tr>
-				<tr id="role-map-rowheader">
+				<tr data-id="role-map-rowheader">
 					<th><a class="role-reference" href="#rowheader"><code>rowheader</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_ROWHEADER</code></span><br />
@@ -1696,7 +1696,7 @@ var mappingTableLabels = {
 					</td>
 
 				</tr>
-				<tr id="role-map-scrollbar">
+				<tr data-id="role-map-scrollbar">
 					<th><a class="role-reference" href="#scrollbar"><code>scrollbar</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_SCROLLBAR</code></span><br />
@@ -1716,7 +1716,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-search">
+				<tr data-id="role-map-search">
 					<th><a class="role-reference" href="#search"><code>search</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br />
@@ -1736,7 +1736,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXLandmarkSearch</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-searchbox">
+				<tr data-id="role-map-searchbox">
 					<th><a class="role-reference" href="#searchbox"><code>searchbox</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_TEXT</code></span><br />
@@ -1756,7 +1756,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXSearchField</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-separator">
+				<tr data-id="role-map-separator">
 					<th><a class="role-reference" href="#separator"><code>separator</code></a> (non-focusable)</th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_SEPARATOR</code></span>
@@ -1772,7 +1772,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-separator-focusable">
+				<tr data-id="role-map-separator-focusable">
 					<th><a class="role-reference" href="#separator"><code>separator</code></a> (focusable)</th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_SEPARATOR</code></span><br />
@@ -1792,7 +1792,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-slider">
+				<tr data-id="role-map-slider">
 					<th><a class="role-reference" href="#slider"><code>slider</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_SLIDER</code></span><br />
@@ -1812,7 +1812,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-spinbutton">
+				<tr data-id="role-map-spinbutton">
 					<th><a class="role-reference" href="#spinbutton"><code>spinbutton</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_SPINBUTTON</code></span><br />
@@ -1832,7 +1832,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-status">
+				<tr data-id="role-map-status">
 					<th><a class="role-reference" href="#status"><code>status</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_STATUSBAR</code></span><br />
@@ -1856,7 +1856,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXApplicationStatus</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-strong">
+				<tr data-id="role-map-strong">
 					<th><a class="role-reference" href="#strong"><code>strong</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span><br />
@@ -1875,7 +1875,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXStrongStyleGroup</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-subscript">
+				<tr data-id="role-map-subscript">
 					<th><a class="role-reference" href="#subscript"><code>subscript</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br />
@@ -1894,7 +1894,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXSubscriptStyleGroup</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-suggestion">
+				<tr data-id="role-map-suggestion">
 					<th><a class="role-reference" href="#suggestion"><code>suggestion</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_SUGGESTION</code></span><br />
@@ -1912,7 +1912,7 @@ var mappingTableLabels = {
 						<span class="property">AXRole: <code>AXGroup</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-superscript">
+				<tr data-id="role-map-superscript">
 					<th><a class="role-reference" href="#superscript"><code>superscript</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br />
@@ -1931,7 +1931,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXSuperscriptStyleGroup</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-switch">
+				<tr data-id="role-map-switch">
 					<th><a class="role-reference" href="#switch"><code>switch</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_CHECKBUTTON</code></span><br />
@@ -1956,7 +1956,7 @@ var mappingTableLabels = {
 						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
 					</td>
 				</tr>
-				<tr id="role-map-tab">
+				<tr data-id="role-map-tab">
 					<th><a class="role-reference" href="#tab"><code>tab</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_PAGETAB</code></span><br />
@@ -1974,7 +1974,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-table">
+				<tr data-id="role-map-table">
 					<th><a class="role-reference" href="#table"><code>table</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_TABLE</code></span><br />
@@ -1999,7 +1999,7 @@ var mappingTableLabels = {
 						<span class="property">AXRowHeaderUIElements: a list of pointers to the rowheader elements</span>
 					</td>
 				</tr>
-				<tr id="role-map-tablist">
+				<tr data-id="role-map-tablist">
 					<th><a class="role-reference" href="#tablist"><code>tablist</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_PAGETABLIST</code></span><br />
@@ -2020,7 +2020,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-tabpanel">
+				<tr data-id="role-map-tabpanel">
 					<th><a class="role-reference" href="#tabpanel"><code>tabpanel</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_PANE</code> or <code>ROLE_SYSTEM_PROPERTYPAGE</code></span>
@@ -2036,7 +2036,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXTabPanel</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-term">
+				<tr data-id="role-map-term">
 					<th><a class="role-reference" href="#term"><code>term</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span><br />
@@ -2058,7 +2058,7 @@ var mappingTableLabels = {
 				<!-- FIXME: This is commented out because the ARIA Working Group agreed to move the text role to ARIA 2.0,
 				but we've not branched for 1.1 yet. Once we have branched, this entire section should be deleted from
 				the 1.1 branch and uncommented for the master branch
-				<tr id="role-map-text">
+				<tr data-id="role-map-text">
 					<th><a class="role-reference" href="#text"><code>text</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_STATICTEXT</code></span>
@@ -2076,7 +2076,7 @@ var mappingTableLabels = {
 				</tr>
 				-->
 
-				<tr id="role-map-textbox">
+				<tr data-id="role-map-textbox">
 					<th><a class="role-reference" href="#textbox"><code>textbox</code></a> when <code>aria-multiline</code> is <code>false</code></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_TEXT</code></span><br />
@@ -2095,7 +2095,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-textbox-multiline">
+				<tr data-id="role-map-textbox-multiline">
 					<th><a class="role-reference" href="#textbox"><code>textbox</code></a> when <code>aria-multiline</code> is <code>true</code></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_TEXT</code></span><br />
@@ -2114,7 +2114,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-time">
+				<tr data-id="role-map-time">
 					<th><a class="role-reference" href="#time"><code>time</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_STATICTEXT</code></span><br />
@@ -2134,7 +2134,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXTimeGroup</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-timer">
+				<tr data-id="role-map-timer">
 					<th><a class="role-reference" href="#timer"><code>timer</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Object Attribute: <code>xml-roles:timer</code></span><br />
@@ -2158,7 +2158,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXApplicationTimer</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-toolbar">
+				<tr data-id="role-map-toolbar">
 					<th><a class="role-reference" href="#toolbar"><code>toolbar</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_TOOLBAR</code></span>
@@ -2174,7 +2174,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-tooltip">
+				<tr data-id="role-map-tooltip">
 					<th><a class="role-reference" href="#tooltip"><code>tooltip</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_TOOLTIP</code></span>
@@ -2190,7 +2190,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>AXUserInterfaceTooltip</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-tree">
+				<tr data-id="role-map-tree">
 					<th><a class="role-reference" href="#tree"><code>tree</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_OUTLINE</code></span><br />
@@ -2210,7 +2210,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-treegrid">
+				<tr data-id="role-map-treegrid">
 					<th><a class="role-reference" href="#treegrid"><code>treegrid</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_OUTLINE</code></span><br />
@@ -2232,7 +2232,7 @@ var mappingTableLabels = {
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>
-				<tr id="role-map-treeitem">
+				<tr data-id="role-map-treeitem">
 					<th><a class="role-reference" href="#treeitem"><code>treeitem</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_OUTLINEITEM</code></span><br />
@@ -2302,7 +2302,7 @@ var mappingTableLabels = {
                 </tr>
               </thead>
               <tbody>
-			<tr id="ariaActiveDescendant">
+			<tr data-id="ariaActiveDescendant">
 				<th><a class="property-reference" href="#aria-activedescendant"><code>aria-activedescendant</code></a></th>
 				<td class="attr-msaa-ia2">
 					See <a href="#focus_state_event_table">Focus Changes</a>.
@@ -2318,7 +2318,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXSelectedRows</code>: pointer to active descendant node</span>
 				</td>
 			</tr>
-			<tr id="ariaAtomicTrue">
+			<tr data-id="ariaAtomicTrue">
 				<th><a class="property-reference" href="#aria-atomic"><code>aria-atomic</code></a>=<code>true</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>atomic:true</code></span><br />
@@ -2343,7 +2343,7 @@ var mappingTableLabels = {
 					<span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
 				</td>
 			</tr>
-			<tr id="ariaAtomicFalse">
+			<tr data-id="ariaAtomicFalse">
 				<th><a class="property-reference" href="#aria-atomic"><code>aria-atomic</code></a>=<code>false</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a>, but if mapped:</span><br />
@@ -2370,7 +2370,7 @@ var mappingTableLabels = {
 					<span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
 				</td>
 			</tr>
-			<tr id="ariaAutocompleteInlineListBoth">
+			<tr data-id="ariaAutocompleteInlineListBoth">
 				<th><a class="property-reference" href="#aria-autocomplete"><code>aria-autocomplete</code></a>=<code>inline</code>, <code>list</code>, or <code>both</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>autocomplete:&lt;value&gt;</code></span><br />
@@ -2387,7 +2387,7 @@ var mappingTableLabels = {
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
 				</td>
 			</tr>
-			<tr id="ariaAutocompleteNone">
+			<tr data-id="ariaAutocompleteNone">
 				<th><a class="property-reference" href="#aria-autocomplete"><code>aria-autocomplete</code></a>=<code>none</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
@@ -2402,7 +2402,7 @@ var mappingTableLabels = {
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
 				</td>
 			</tr>
-			<tr id="ariaBusyTrue">
+			<tr data-id="ariaBusyTrue">
 				<th><a class="state-reference" href="#aria-busy"><code>aria-busy</code></a>=<code>true</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>STATE_SYSTEM_BUSY</code></span>
@@ -2417,7 +2417,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXElementBusy</code>: <code>YES</code></span>
 				</td>
 			</tr>
-			<tr id="ariaBusyFalse">
+			<tr data-id="ariaBusyFalse">
 				<th><a class="state-reference" href="#aria-busy"><code>aria-busy</code></a>=<code>false</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>STATE_SYSTEM_BUSY</code> not exposed</span>
@@ -2432,7 +2432,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXElementBusy</code>: <code>NO</code></span>
 				</td>
 			</tr>
-			<tr id="ariaCheckedTrue">
+			<tr data-id="ariaCheckedTrue">
 				<th><a class="state-reference" href="#aria-checked"><code>aria-checked</code></a>=<code>true</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>STATE_SYSTEM_CHECKED</code></span><br />
@@ -2451,7 +2451,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXMenuItemMarkChar</code>: <code>&#x2713;</code> for <code>menuitemcheckbox</code> and <code>menuitemradio</code></span>
 				</td>
 			</tr>
-			<tr id="ariaCheckedFalse">
+			<tr data-id="ariaCheckedFalse">
 				<th><a class="state-reference" href="#aria-checked"><code>aria-checked</code></a>=<code>false</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>STATE_SYSTEM_CHECKED</code> not exposed</span><br />
@@ -2470,7 +2470,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXMenuItemMarkChar</code>: <code>&lt;nil&gt;</code> for <code>menuitemcheckbox</code> and <code>menuitemradio</code></span>
 				</td>
 			</tr>
-			<tr id="ariaCheckedMixed">
+			<tr data-id="ariaCheckedMixed">
 				<th><a class="state-reference" href="#aria-checked"><code>aria-checked</code></a>=<code>mixed</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>STATE_SYSTEM_MIXED</code></span><br />
@@ -2489,7 +2489,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXMenuItemMarkChar</code>: <code>&lt;nil&gt;</code> for <code>menuitemcheckbox</code> and <code>menuitemradio</code></span>
 				</td>
 			</tr>
-			<tr id="ariaCheckedUndefined">
+			<tr data-id="ariaCheckedUndefined">
 				<th><a class="state-reference" href="#aria-checked"><code>aria-checked</code></a> is undefined</th>
 				<td class="attr-msaa-ia2">
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
@@ -2504,7 +2504,7 @@ var mappingTableLabels = {
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
 				</td>
 			</tr>
-			<tr id="ariaColCount">
+			<tr data-id="ariaColCount">
 				<th><a class="property-reference" href="#aria-colcount"><code>aria-colcount</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>colcount:&lt;value&gt;</code></span><br />
@@ -2521,7 +2521,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXARIAColumnCount</code>: <code>&lt;value&gt;</code></span>
 				</td>
 			</tr>
-			<tr id="ariaColIndex">
+			<tr data-id="ariaColIndex">
 				<th><a class="property-reference" href="#aria-colindex"><code>aria-colindex</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>colindex:&lt;value&gt;</code></span><br />
@@ -2538,7 +2538,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXARIAColumnIndex</code>: <code>&lt;value&gt;</code></span>
 				</td>
 			</tr>
-			<tr id="ariaColIndexText">
+			<tr data-id="ariaColIndexText">
 				<th><a class="property-reference" href="#aria-colindextext"><code>aria-colindextext</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>colindextext:&lt;value&gt;</code></span>
@@ -2553,7 +2553,7 @@ var mappingTableLabels = {
 					<span class="property">Property: TBD</span>
 				</td>
 			</tr>
-			<tr id="ariaColSpan">
+			<tr data-id="ariaColSpan">
 				<th><a class="property-reference" href="#aria-colspan"><code>aria-colspan</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>colspan:&lt;value&gt;</code></span><br />
@@ -2570,7 +2570,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXColumnIndexRange.length</code>: <code>&lt;value&gt;</code></span>
 				</td>
 			</tr>
-			<tr id="ariaControls">
+			<tr data-id="ariaControls">
 				<th><a class="property-reference" href="#aria-controls"><code>aria-controls</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="relation">Relation: <code>IA2_RELATION_CONTROLLER_FOR</code> points to accessible nodes matching IDREFs</span><br />
@@ -2589,7 +2589,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXLinkedUIElements</code>: pointers to accessible nodes matching IDREFs</span>
 				</td>
 			</tr>
-			<tr id="ariaCurrent">
+			<tr data-id="ariaCurrent">
 				<th><a class="state-reference" href="#aria-current"><code>aria-current</code></a> with non-<code>false</code> allowed value</th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>current:&lt;value&gt;</code></span>
@@ -2605,7 +2605,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXARIACurrent</code>: <code>&lt;value&gt;</code></span>
 				</td>
 			</tr>
-			<tr id="ariaCurrentUnrecognizedValue">
+			<tr data-id="ariaCurrentUnrecognizedValue">
 				<th><a class="state-reference" href="#aria-current"><code>aria-current</code></a> with unrecognized value</th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>current:true</code></span>
@@ -2621,7 +2621,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXARIACurrent</code>: <code>true</code></span>
 				</td>
 			</tr>
-			<tr id="ariaCurrentUndefined">
+			<tr data-id="ariaCurrentUndefined">
 				<th><a class="state-reference" href="#aria-current"><code>aria-current</code></a> is <code>false</code> or undefined</th>
 				<td class="attr-msaa-ia2">
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
@@ -2636,7 +2636,7 @@ var mappingTableLabels = {
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
 				</td>
 			</tr>
-			<tr id="ariaDescribedBy">
+			<tr data-id="ariaDescribedBy">
 				<th><a class="property-reference" href="#aria-describedby"><code>aria-describedby</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Property: <code>accDescription</code>: <code>&lt;value&gt;</code></span><br />
@@ -2660,7 +2660,7 @@ var mappingTableLabels = {
 					<span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
 				</td>
 			</tr>
-			<tr id="ariaDescription">
+			<tr data-id="ariaDescription">
 				<th><a class="property-reference" href="#aria-description"><code>aria-description</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Property: <code>accDescription</code>: <code>&lt;value&gt;</code></span><br />
@@ -2679,7 +2679,7 @@ var mappingTableLabels = {
 					<span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
 				</td>
 			</tr>
-			<tr id="ariaDetails">
+			<tr data-id="ariaDetails">
 				<th><a class="property-reference" href="#aria-details"><code>aria-details</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="relation">Relation: <code>IA2_RELATION_DETAILS</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
@@ -2698,7 +2698,7 @@ var mappingTableLabels = {
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
 				</td>
 			</tr>
-			<tr id="ariaDisabledTrue">
+			<tr data-id="ariaDisabledTrue">
 				<th><a class="state-reference" href="#aria-disabled"><code>aria-disabled</code></a>=<code>true</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>STATE_SYSTEM_UNAVAILABLE</code></span><br />
@@ -2714,7 +2714,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXEnabled</code>: <code>NO</code></span>
 				</td>
 			</tr>
-			<tr id="ariaDisabledFalse">
+			<tr data-id="ariaDisabledFalse">
 				<th><a class="state-reference" href="#aria-disabled"><code>aria-disabled</code></a>=<code>false</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>STATE_SYSTEM_UNAVAILABLE</code> not exposed</span>
@@ -2729,7 +2729,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXEnabled</code>: <code>YES</code></span>
 				</td>
 			</tr>
-			<tr id="ariaDropeffectMoveLinkExecutePopup">
+			<tr data-id="ariaDropeffectMoveLinkExecutePopup">
 				<th><a class="property-reference" href="#aria-dropeffect"><code>aria-dropeffect</code></a>=<code>copy</code>, <code>move</code>, <code>link</code>, <code>execute</code>, or <code>popup</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>dropeffect:&lt;value&gt;</code></span>
@@ -2744,7 +2744,7 @@ var mappingTableLabels = {
 					<code>array AXDropEffects</code>
 				</td>
 			</tr>
-			<tr id="ariaDropeffectNone">
+			<tr data-id="ariaDropeffectNone">
 				<th><a class="property-reference" href="#aria-dropeffect"><code>aria-dropeffect</code></a>=<code>none</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>dropeffect:none</code> if there are no other valid tokens</span><br />
@@ -2761,7 +2761,7 @@ var mappingTableLabels = {
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
 				</td>
 			</tr>
-			<tr id="ariaErrorMessage">
+			<tr data-id="ariaErrorMessage">
 				<th><a class="property-reference" href="#aria-errormessage"><code>aria-errormessage</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="relation">Relation: <code>IA2_RELATION_ERROR</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
@@ -2780,7 +2780,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXValidationError</code>: textual content of the referenced element</span>
 				</td>
 			</tr>
-			<tr id="ariaExpandedTrue">
+			<tr data-id="ariaExpandedTrue">
 				<th><a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a>=<code>true</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>STATE_SYSTEM_EXPANDED</code></span>
@@ -2796,7 +2796,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXExpanded</code>: <code>YES</code></span>
 				</td>
 			</tr>
-			<tr id="ariaExpandedFalse">
+			<tr data-id="ariaExpandedFalse">
 				<th><a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a>=<code>false</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>STATE_SYSTEM_COLLAPSED</code></span>
@@ -2812,7 +2812,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXExpanded</code>: <code>NO</code></span>
 				</td>
 			</tr>
-			<tr id="ariaExpandedUndefined">
+			<tr data-id="ariaExpandedUndefined">
 				<th><a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a> is undefined</th>
 				<td class="attr-msaa-ia2">
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
@@ -2827,7 +2827,7 @@ var mappingTableLabels = {
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
 				</td>
 			</tr>
-			<tr id="ariaFlowto">
+			<tr data-id="ariaFlowto">
 				<th><a class="property-reference" href="#aria-flowto"><code>aria-flowto</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="relation">Relation: <code>IA2_RELATION_FLOW_TO</code> points to accessible nodes matching IDREFs</span><br />
@@ -2846,7 +2846,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXLinkedUIElements</code>: pointers to accessible nodes matching IDREFs</span>
 				</td>
 			</tr>
-			<tr id="ariaGrabbedTrue">
+			<tr data-id="ariaGrabbedTrue">
 				<th><a class="state-reference" href="#aria-grabbed"><code>aria-grabbed</code></a>=<code>true</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>grabbed:true</code></span>
@@ -2861,7 +2861,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXGrabbed</code>: <code>YES</code></span>
 				</td>
 			</tr>
-			<tr id="ariaGrabbedFalse">
+			<tr data-id="ariaGrabbedFalse">
 				<th><a class="state-reference" href="#aria-grabbed"><code>aria-grabbed</code></a>=<code>false</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>grabbed:false</code></span>
@@ -2876,7 +2876,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXGrabbed</code>: <code>NO</code></span>
 				</td>
 			</tr>
-			<tr id="ariaGrabbedUndefined">
+			<tr data-id="ariaGrabbedUndefined">
 				<th><a class="state-reference" href="#aria-grabbed"><code>aria-grabbed</code></a> is undefined</th>
 				<td class="attr-msaa-ia2">
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
@@ -2891,7 +2891,7 @@ var mappingTableLabels = {
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
 				</td>
 			</tr>
-			<tr id="ariaHaspopupTrue">
+			<tr data-id="ariaHaspopupTrue">
 				<th><a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a>=<code>true</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span><br />
@@ -2909,7 +2909,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>Action</code>: <code>AXShowMenu</code></span>
 				</td>
 			</tr>
-			<tr id="ariaHaspopupFalse">
+			<tr data-id="ariaHaspopupFalse">
 				<th><a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a>=<code>false</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code> not exposed</span><br />
@@ -2925,7 +2925,7 @@ var mappingTableLabels = {
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
 				</td>
 			</tr>
-			<tr id="ariaHaspopupDialog">
+			<tr data-id="ariaHaspopupDialog">
 				<th><a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a>=<code>dialog</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span><br />
@@ -2943,7 +2943,7 @@ var mappingTableLabels = {
 					<span class="action">Action: <code>AXShowMenu</code></span>
 				</td>
 			</tr>
-			<tr id="ariaHaspopupListbox">
+			<tr data-id="ariaHaspopupListbox">
 				<th><a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a>=<code>listbox</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span><br />
@@ -2961,7 +2961,7 @@ var mappingTableLabels = {
 					<span class="action">Action: <code>AXShowMenu</code></span>
 				</td>
 			</tr>
-			<tr id="ariaHaspopupMenu">
+			<tr data-id="ariaHaspopupMenu">
 				<th><a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a>=<code>menu</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span><br />
@@ -2979,7 +2979,7 @@ var mappingTableLabels = {
 					<span class="action">Action: <code>AXShowMenu</code></span>
 				</td>
 			</tr>
-			<tr id="ariaHaspopupTree">
+			<tr data-id="ariaHaspopupTree">
 				<th><a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a>=<code>tree</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span><br />
@@ -2997,7 +2997,7 @@ var mappingTableLabels = {
 					<span class="action">Action: <code>AXShowMenu</code></span>
 				</td>
 			</tr>
-			<tr id="ariaHiddenTrue">
+			<tr data-id="ariaHiddenTrue">
 				<th><a class="state-reference" href="#aria-hidden"><code>aria-hidden</code></a>=<code>true</code> on unfocused element</th>
 				<td class="attr-msaa-ia2">
 					<span class="property not-in-tree">Element SHOULD NOT be exposed</span><br />
@@ -3016,7 +3016,7 @@ var mappingTableLabels = {
 					<span class="seealso">See also: <a class="specref" href="#tree_inclusion">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a></span>
 				</td>
 			</tr>
-			<tr id="ariaHiddenTrueElementExposed">
+			<tr data-id="ariaHiddenTrueElementExposed">
 				<th><a class="state-reference" href="#aria-hidden"><code>aria-hidden</code></a>=<code>true</code> when element is focused or fires an accessibility event</th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>hidden:true</code></span><br />
@@ -3035,7 +3035,7 @@ var mappingTableLabels = {
 					<span class="seealso">See also: <a class="specref" href="#tree_inclusion">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a></span>
 				</td>
 			</tr>
-			<tr id="ariaHiddenFalse">
+			<tr data-id="ariaHiddenFalse">
 				<th><a class="state-reference" href="#aria-hidden"><code>aria-hidden</code></a>=<code>false</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
@@ -3050,7 +3050,7 @@ var mappingTableLabels = {
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
 				</td>
 			</tr>
-			<tr id="ariaInvalidTrue">
+			<tr data-id="ariaInvalidTrue">
 				<th><a class="state-reference" href="#aria-invalid"><code>aria-invalid</code></a>=<code>true</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>IA2_STATE_INVALID_ENTRY</code></span><br />
@@ -3067,7 +3067,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXInvalid</code>: <code>true</code></span>
 				</td>
 			</tr>
-			<tr id="ariaInvalidFalse">
+			<tr data-id="ariaInvalidFalse">
 				<th><a class="state-reference" href="#aria-invalid"><code>aria-invalid</code></a>=<code>false</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>IA2_STATE_INVALID_ENTRY</code> not exposed</span>
@@ -3082,7 +3082,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXInvalid</code>: <code>false</code></span>
 				</td>
 			</tr>
-			<tr id="ariaInvalidSpellingGrammar">
+			<tr data-id="ariaInvalidSpellingGrammar">
 				<th><a class="state-reference" href="#aria-invalid"><code>aria-invalid</code></a>=<code>spelling</code> or <code>grammar</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>IA2_STATE_INVALID_ENTRY</code></span><br />
@@ -3099,7 +3099,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXInvalid</code>: <code>&lt;value&gt;</code></span>
 				</td>
 			</tr>
-			<tr id="ariaInvalidUnrecognizedValue">
+			<tr data-id="ariaInvalidUnrecognizedValue">
 				<th><a class="state-reference" href="#aria-invalid"><code>aria-invalid</code></a> with unrecognized value</th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>IA2_STATE_INVALID_ENTRY</code></span><br />
@@ -3116,7 +3116,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXInvalid</code>: <code>true</code></span>
 				</td>
 			</tr>
-			<tr id="ariaKeyshortcuts">
+			<tr data-id="ariaKeyshortcuts">
 				<th><a class="property-reference" href="#aria-keyshortcuts"><code>aria-keyshortcuts</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Property: <code>accKeyboardShortcut</code>: <code>&lt;value&gt;</code></span>
@@ -3131,7 +3131,7 @@ var mappingTableLabels = {
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
 				</td>
 			</tr>
-			<tr id="ariaLabel">
+			<tr data-id="ariaLabel">
 				<th><a class="property-reference" href="#aria-label"><code>aria-label</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Property: <code>accName</code>: <code>&lt;value&gt;</code></span><br />
@@ -3150,7 +3150,7 @@ var mappingTableLabels = {
 					<span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
 				</td>
 			</tr>
-			<tr id="ariaLabelledBy">
+			<tr data-id="ariaLabelledBy">
 				<th><a class="property-reference" href="#aria-labelledby"><code>aria-labelledby</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Property: <code>accName</code>: <code>&lt;value&gt;</code></span><br />
@@ -3176,7 +3176,7 @@ var mappingTableLabels = {
 					<span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
 				</td>
 			</tr>
-			<tr id="ariaLevel">
+			<tr data-id="ariaLevel">
 				<th><a class="property-reference" href="#aria-level"><code>aria-level</code></a> on non-<code>heading</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>level:&lt;value&gt;</code></span><br />
@@ -3194,7 +3194,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXDisclosureLevel</code>: <code>&lt;value&gt;</code> (zero-based), when used on an outline row (like a <a class="role-reference" href="#treeitem"><code>treeitem</code></a> or <a class="role-reference" href="#group"><code>group</code></a>)</span>
 				</td>
 			</tr>
-			<tr id="ariaLevelHeading">
+			<tr data-id="ariaLevelHeading">
 				<th><a class="property-reference" href="#aria-level"><code>aria-level</code></a> on <code>heading</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>level:&lt;value&gt;</code></span>
@@ -3210,7 +3210,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXValue</code>: <code>&lt;value&gt;</code></span>
 				</td>
 			</tr>
-			<tr id="ariaLiveAssertive">
+			<tr data-id="ariaLiveAssertive">
 				<th><a class="property-reference" href="#aria-live"><code>aria-live</code></a>=<code>assertive</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>live:assertive</code></span><br />
@@ -3233,7 +3233,7 @@ var mappingTableLabels = {
 					<span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
 				</td>
 			</tr>
-			<tr id="ariaLivePolite">
+			<tr data-id="ariaLivePolite">
 				<th><a class="property-reference" href="#aria-live"><code>aria-live</code></a>=<code>polite</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>live:polite</code></span><br />
@@ -3256,7 +3256,7 @@ var mappingTableLabels = {
 					<span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
 				</td>
 			</tr>
-			<tr id="ariaLiveOff">
+			<tr data-id="ariaLiveOff">
 				<th><a class="property-reference" href="#aria-live"><code>aria-live</code></a>=<code>off</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>live:off</code></span><br />
@@ -3275,7 +3275,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXARIALive</code>: <code>&quot;off&quot;</code></span>
 				</td>
 			</tr>
-			<tr id="ariaModalTrue">
+			<tr data-id="ariaModalTrue">
 				<th><a class="property-reference" href="#aria-modal"><code>aria-modal</code></a>=<code>true</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>IA2_STATE_MODAL</code></span>
@@ -3290,7 +3290,7 @@ var mappingTableLabels = {
 					Prune the accessibility tree such that the background content is no longer exposed. No specific property is set on the <a class="termref">accessible object</a> that corresponds to the <a class="termref">element</a> with <code>aria-modal="true"</code>. Only the tree whose root is that modal accessible object is exposed.
 				</td>
 			</tr>
-			<tr id="ariaModalFalse">
+			<tr data-id="ariaModalFalse">
 				<th><a class="property-reference" href="#aria-modal"><code>aria-modal</code></a>=<code>false</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>IA2_STATE_MODAL</code> not exposed</span>
@@ -3305,7 +3305,7 @@ var mappingTableLabels = {
 					Grow the accessibility tree such that the background content is exposed. No specific property is set on the <a class="termref">accessible object</a> that corresponds to the <a class="termref">element</a> with <code>aria-modal="false"</code>.
 				</td>
 			</tr>
-			<tr id="ariaMultilineTrue">
+			<tr data-id="ariaMultilineTrue">
 				<th><a class="property-reference" href="#aria-multiline"><code>aria-multiline</code></a>=<code>true</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>IA2_STATE_MULTI_LINE</code></span><br />
@@ -3323,7 +3323,7 @@ var mappingTableLabels = {
 					<span class="seealso">See also: <a href="#role-map-textbox"><code>textbox</code></a> in the Role Mapping Table</span>
 				</td>
 			</tr>
-			<tr id="ariaMultilineFalse">
+			<tr data-id="ariaMultilineFalse">
 				<th><a class="property-reference" href="#aria-multiline"><code>aria-multiline</code></a>=<code>false</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>IA2_STATE_SINGLE_LINE</code></span><br />
@@ -3341,7 +3341,7 @@ var mappingTableLabels = {
 					<span class="seealso">See also: <a href="#role-map-textbox"><code>textbox</code></a> in the Role Mapping Table</span>
 				</td>
 			</tr>
-			<tr id="ariaMultiselectableTrue">
+			<tr data-id="ariaMultiselectableTrue">
 				<th><a class="property-reference" href="#aria-multiselectable"><code>aria-multiselectable</code></a>=<code>true</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>STATE_SYSTEM_MULTISELECTABLE</code></span><br />
@@ -3361,7 +3361,7 @@ var mappingTableLabels = {
 					<span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
 				</td>
 			</tr>
-			<tr id="ariaMultiselectableFalse">
+			<tr data-id="ariaMultiselectableFalse">
 				<th><a class="property-reference" href="#aria-multiselectable"><code>aria-multiselectable</code></a>=<code>false</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>STATE_SYSTEM_MULTISELECTABLE</code> not exposed</span><br />
@@ -3378,7 +3378,7 @@ var mappingTableLabels = {
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
 				</td>
 			</tr>
-			<tr id="ariaOrientationHorizontal">
+			<tr data-id="ariaOrientationHorizontal">
 				<th><a class="property-reference" href="#aria-orientation"><code>aria-orientation</code></a>=<code>horizontal</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>IA2_STATE_HORIZONTAL</code></span><br />
@@ -3395,7 +3395,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXOrientation</code>: <code>AXHorizontalOrientation</code></span>
 				</td>
 			</tr>
-			<tr id="ariaOrientationVertical">
+			<tr data-id="ariaOrientationVertical">
 				<th><a class="property-reference" href="#aria-orientation"><code>aria-orientation</code></a>=<code>vertical</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>IA2_STATE_VERTICAL</code></span><br />
@@ -3412,7 +3412,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXOrientation</code>: <code>AXVerticalOrientation</code></span>
 				</td>
 			</tr>
-			<tr id="ariaOrientationUndefined">
+			<tr data-id="ariaOrientationUndefined">
 				<th><a class="property-reference" href="#aria-orientation"><code>aria-orientation</code></a> is undefined</th>
 				<td class="attr-msaa-ia2">
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
@@ -3428,7 +3428,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXOrientation</code>: <code>AXUnknownOrientation</code></span>
 				</td>
 			</tr>
-			<tr id="ariaOwns">
+			<tr data-id="ariaOwns">
 				<th><a class="property-reference" href="#aria-owns"><code>aria-owns</code></a></th>
 				<td class="attr-msaa-ia2">
                                         <p>User agents MAY expose the elements that are referenced by this property as children of the current element. In which case, if multiple <a class="property-reference" href="#aria-owns"><code>aria-owns</code></a> relationships are found, use only the first one.	If the accessibility tree is not modified, expose as:</p>
@@ -3449,7 +3449,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXOwns</code>: pointers to accessible nodes matching IDREFs</span>
 				</td>
 			</tr>
-			<tr id="ariaPlaceholder">
+			<tr data-id="ariaPlaceholder">
 				<th><a class="property-reference" href="#aria-placeholder"><code>aria-placeholder</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>placeholder-text:&lt;value&gt;</code></span>
@@ -3464,7 +3464,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXPlaceholderValue</code>: <code>&lt;value&gt;</code></span>
 				</td>
 			</tr>
-			<tr id="ariaPosinset">
+			<tr data-id="ariaPosinset">
 				<th><a class="property-reference" href="#aria-posinset"><code>aria-posinset</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>posinset:&lt;value&gt;</code></span><br />
@@ -3483,7 +3483,7 @@ var mappingTableLabels = {
 					<span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
 				</td>
 			</tr>
-			<tr id="ariaPressedTrue">
+			<tr data-id="ariaPressedTrue">
 				<th><a class="state-reference" href="#aria-pressed"><code>aria-pressed</code></a>=<code>true</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>STATE_SYSTEM_PRESSED</code></span><br />
@@ -3501,7 +3501,7 @@ var mappingTableLabels = {
 					<span class="seealso">See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span>
 				</td>
 			</tr>
-			<tr id="ariaPressedMixed">
+			<tr data-id="ariaPressedMixed">
 				<th><a class="state-reference" href="#aria-pressed"><code>aria-pressed</code></a>=<code>mixed</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>STATE_SYSTEM_MIXED</code></span><br />
@@ -3519,7 +3519,7 @@ var mappingTableLabels = {
 					<span class="seealso">See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span>
 				</td>
 			</tr>
-			<tr id="ariaPressedFalse">
+			<tr data-id="ariaPressedFalse">
 				<th><a class="state-reference" href="#aria-pressed"><code>aria-pressed</code></a>=<code>false</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>STATE_SYSTEM_PRESSED</code> not exposed</span><br />
@@ -3537,7 +3537,7 @@ var mappingTableLabels = {
 					<span class="seealso">See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span>
 				</td>
 			</tr>
-			<tr id="ariaPressedUndefined">
+			<tr data-id="ariaPressedUndefined">
 				<th><a class="state-reference" href="#aria-pressed"><code>aria-pressed</code></a> is undefined</th>
 				<td class="attr-msaa-ia2">
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
@@ -3552,7 +3552,7 @@ var mappingTableLabels = {
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
 				</td>
 			</tr>
-			<tr id="ariaReadonlyTrue">
+			<tr data-id="ariaReadonlyTrue">
 				<th><a class="property-reference" href="#aria-readonly"><code>aria-readonly</code></a>=<code>true</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>STATE_SYSTEM_READONLY</code></span>
@@ -3570,7 +3570,7 @@ var mappingTableLabels = {
 					<span class="method">Method: <code>AXUIElementIsAttributeSettable(AXValue)</code>: <code>NO</code></span>
 				</td>
 			</tr>
-			<tr id="ariaReadonlyFalse">
+			<tr data-id="ariaReadonlyFalse">
 				<th><a class="property-reference" href="#aria-readonly"><code>aria-readonly</code></a>=<code>false</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>STATE_SYSTEM_READONLY</code> not exposed</span><br />
@@ -3586,7 +3586,7 @@ var mappingTableLabels = {
 					<span class="method">Method: <code>AXUIElementIsAttributeSettable(AXValue)</code>: <code>YES</code></span>
 				</td>
 			</tr>
-			<tr id="ariaReadonlyUnspecifiedOnGridcell">
+			<tr data-id="ariaReadonlyUnspecifiedOnGridcell">
 				<th><a class="property-reference" href="#aria-readonly"><code>aria-readonly</code></a> is unspecified on <code>gridcell</code></th>
 				<td class="attr-msaa-ia2">
 					The <code>gridcell</code> MUST inherit any author-provided value for <code>aria-readonly</code> from the containing <code>grid</code> or <code>treegrid</code>. Expose the inherited value on the <code>gridcell</code> as described for <a href="#ariaReadonlyTrue"><code>aria-readonly="true"</code></a> and <a href="#ariaReadonlyFalse"><code>aria-readonly="false"</code></a>.
@@ -3601,7 +3601,7 @@ var mappingTableLabels = {
 					The <code>gridcell</code> MUST inherit any author-provided value for <code>aria-readonly</code> from the containing <code>grid</code> or <code>treegrid</code>. Expose the inherited value on the <code>gridcell</code> as described for <a href="#ariaReadonlyTrue"><code>aria-readonly="true"</code></a> and <a href="#ariaReadonlyFalse"><code>aria-readonly="false"</code></a>.
 				</td>
 			</tr>
-			<tr id="ariaRelevant">
+			<tr data-id="ariaRelevant">
 				<th><a class="property-reference" href="#aria-relevant"><code>aria-relevant</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>relevant:&lt;value&gt;</code></span><br />
@@ -3624,7 +3624,7 @@ var mappingTableLabels = {
 					<span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
 				</td>
 			</tr>
-			<tr id="ariaRequiredTrue">
+			<tr data-id="ariaRequiredTrue">
 				<th><a class="property-reference" href="#aria-required"><code>aria-required</code></a>=<code>true</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>IA2_STATE_REQUIRED</code></span>
@@ -3639,7 +3639,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXRequired</code>: <code>YES</code></span>
 				</td>
 			</tr>
-			<tr id="ariaRequiredFalse">
+			<tr data-id="ariaRequiredFalse">
 				<th><a class="property-reference" href="#aria-required"><code>aria-required</code></a>=<code>false</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
@@ -3654,7 +3654,7 @@ var mappingTableLabels = {
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
 				</td>
 			</tr>
-			<tr id="ariaRoleDescription">
+			<tr data-id="ariaRoleDescription">
 				<th><a class="property-reference" href="#aria-roledescription"><code>aria-roledescription</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="method">Method: <code>localizedExtendedRole()</code>: <code>&lt;value&gt;</code></span>
@@ -3669,7 +3669,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXRoleDescription</code>: <code>&lt;value&gt;</code></span>
 				</td>
 			</tr>
-			<tr id="ariaRoleDescriptionEmptyWhiteSpaceString">
+			<tr data-id="ariaRoleDescriptionEmptyWhiteSpaceString">
 				<th><a class="property-reference" href="#aria-roledescription"><code>aria-roledescription</code></a> is empty or whitespace characters</th>
 				<td class="attr-msaa-ia2">
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
@@ -3684,7 +3684,7 @@ var mappingTableLabels = {
 					<span class="property">AXRoleDescription is defined as that specified for the role of the element: based on the explicit role if the role attribute is provided; otherwise, based on the implicit role for the host language.</span>
 				</td>
 			</tr>
-			<tr id="ariaRowCount">
+			<tr data-id="ariaRowCount">
 				<th><a class="property-reference" href="#aria-rowcount"><code>aria-rowcount</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>rowcount:&lt;value&gt;</code></span><br />
@@ -3701,7 +3701,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXARIARowCount</code>: <code>&lt;value&gt;</code></span>
 				</td>
 			</tr>
-			<tr id="ariaRowIndex">
+			<tr data-id="ariaRowIndex">
 				<th><a class="property-reference" href="#aria-rowindex"><code>aria-rowindex</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>rowindex:&lt;value&gt;</code></span><br />
@@ -3718,7 +3718,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXARIARowIndex</code>: <code>&lt;value&gt;</code></span>
 				</td>
 			</tr>
-			<tr id="ariaRowIndexText">
+			<tr data-id="ariaRowIndexText">
 				<th><a class="property-reference" href="#aria-rowindextext"><code>aria-rowindextext</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>rowindextext:&lt;value&gt;</code></span>
@@ -3733,7 +3733,7 @@ var mappingTableLabels = {
 					<span class="property">Property: TBD</span>
 				</td>
 			</tr>
-			<tr id="ariaRowSpan">
+			<tr data-id="ariaRowSpan">
 				<th><a class="property-reference" href="#aria-rowspan"><code>aria-rowspan</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>rowspan:&lt;value&gt;</code></span><br />
@@ -3750,7 +3750,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXRowIndexRange.length</code>: <code>&lt;value&gt;</code></span>
 				</td>
 			</tr>
-			<tr id="ariaSelectedTrue">
+			<tr data-id="ariaSelectedTrue">
 				<th><a class="state-reference" href="#aria-selected"><code>aria-selected</code></a>=<code>true</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>STATE_SYSTEM_SELECTABLE</code></span><br />
@@ -3770,7 +3770,7 @@ var mappingTableLabels = {
 				</td>
 			</tr>
 
-			<tr id="ariaSelectedFalse">
+			<tr data-id="ariaSelectedFalse">
 				<th><a class="state-reference" href="#aria-selected"><code>aria-selected</code></a>=<code>false</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">State: <code>STATE_SYSTEM_SELECTABLE</code></span><br />
@@ -3789,7 +3789,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXSelected</code>: <code>NO</code></span>
 				</td>
 			</tr>
-			<tr id="ariaSelectedUndefined">
+			<tr data-id="ariaSelectedUndefined">
 				<th><a class="state-reference" href="#aria-selected"><code>aria-selected</code></a> is undefined</th>
 				<td class="attr-msaa-ia2">
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
@@ -3804,7 +3804,7 @@ var mappingTableLabels = {
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
 				</td>
 			</tr>
-			<tr id="ariaSetsize">
+			<tr data-id="ariaSetsize">
 				<th><a class="property-reference" href="#aria-setsize"><code>aria-setsize</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>setsize:&lt;value&gt;</code></span><br />
@@ -3825,7 +3825,7 @@ var mappingTableLabels = {
 					<span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
 				</td>
 			</tr>
-			<tr id="ariaSortAscending">
+			<tr data-id="ariaSortAscending">
 				<th><a class="property-reference" href="#aria-sort"><code>aria-sort</code></a>=<code>ascending</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>sort:ascending</code></span>
@@ -3841,7 +3841,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXSortDirection</code>: <code>AXAscendingSortDirection</code></span>
 				</td>
 			</tr>
-			<tr id="ariaSortDescending">
+			<tr data-id="ariaSortDescending">
 				<th><a class="property-reference" href="#aria-sort"><code>aria-sort</code></a>=<code>descending</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>sort:descending</code></span>
@@ -3857,7 +3857,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXSortDirection</code>: <code>AXDescendingSortDirection</code></span>
 				</td>
 			</tr>
-			<tr id="ariaSortOther">
+			<tr data-id="ariaSortOther">
 				<th><a class="property-reference" href="#aria-sort"><code>aria-sort</code></a>=<code>other</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>sort:other</code></span>
@@ -3873,7 +3873,7 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXSortDirection</code>: <code>AXUnknownSortDirection</code></span>
 				</td>
 			</tr>
-			<tr id="ariaSortNone">
+			<tr data-id="ariaSortNone">
 				<th><a class="property-reference" href="#aria-sort"><code>aria-sort</code></a>=<code>none</code></th>
 				<td class="attr-msaa-ia2">
 					<span class="property">Object Attribute: <code>sort:none</code>, if the value is not unspecified</span>
@@ -3888,7 +3888,7 @@ var mappingTableLabels = {
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
 				</td>
 			</tr>
-			<tr id="ariaValueMax">
+			<tr data-id="ariaValueMax">
 				<th><a class="property-reference" href="#aria-valuemax"><code>aria-valuemax</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="method">Method: <code>IAccessibleValue::maximumValue()</code>: <code>&lt;value&gt;</code></span><br />
@@ -3907,7 +3907,7 @@ var mappingTableLabels = {
 					<span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
 				</td>
 			</tr>
-			<tr id="ariaValueMin">
+			<tr data-id="ariaValueMin">
 				<th><a class="property-reference" href="#aria-valuemin"><code>aria-valuemin</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="method">Method: <code>IAccessibleValue::minimumValue()</code>: <code>&lt;value&gt;</code></span><br />
@@ -3926,7 +3926,7 @@ var mappingTableLabels = {
 					<span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
 				</td>
 			</tr>
-			<tr id="ariaValueNow">
+			<tr data-id="ariaValueNow">
 				<th><a class="property-reference" href="#aria-valuenow"><code>aria-valuenow</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="method">Method: <code>IAccessibleValue::currentValue()</code>: <code>&lt;value&gt;</code></span><br />
@@ -3946,7 +3946,7 @@ var mappingTableLabels = {
 					<span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
 				</td>
 			</tr>
-			<tr id="ariaValueText">
+			<tr data-id="ariaValueText">
 				<th><a class="property-reference" href="#aria-valuetext"><code>aria-valuetext</code></a></th>
 				<td class="attr-msaa-ia2">
 					<span class="method">Method: <code>IAccessible::get_accValue()</code>: <code>&lt;value&gt;</code></span><br />
@@ -4053,7 +4053,7 @@ var mappingTableLabels = {
             </tr>
           </thead>
           <tbody>
-            <tr id="event-aria-activedescendant">
+            <tr data-id="event-aria-activedescendant">
               <th><a class="property-reference" href="#aria-activedescendant"><code>aria-activedescendant</code></a></th>
               <td>See <a href="#focus_state_event_table">Focus Changes</a>.
                 <p>In addition: </p>
@@ -4067,7 +4067,7 @@ var mappingTableLabels = {
               <td>See <a href="#focus_state_event_table">Focus Changes</a>.
                 <p>In addition: <code>AXSelectedChildrenChanged</code></p></td>
               </tr>
-            <tr id="event-aria-busy">
+            <tr data-id="event-aria-busy">
               <th><a class="state-reference" href="#aria-busy"><code>aria-busy</code></a> (state)</th>
               <td><code>EVENT_OBJECT_STATECHANGE</code></td>
               <td>
@@ -4077,7 +4077,7 @@ var mappingTableLabels = {
               <td><code>object:state-changed:busy</code></td>
               <td><code>AXElementBusyChanged</code></td>
             </tr>            
-          <tr id="event-aria-checked">
+          <tr data-id="event-aria-checked">
           	<th><a class="state-reference" href="#aria-checked"><code>aria-checked</code></a> (state)</th>
               <td><code>EVENT_OBJECT_STATECHANGE</code></td>
               <td>
@@ -4087,7 +4087,7 @@ var mappingTableLabels = {
               <td><code>object:state-changed:checked</code></td>
               <td><code>AXValueChanged</code></td>
             </tr>
-          <tr id="event-aria-current">
+          <tr data-id="event-aria-current">
               <th><a class="state-reference" href="#aria-current"><code>aria-current</code></a> (state)</th>
               <td><code>IA2_EVENT_OBJECT_ATTRIBUTE_CHANGED</code></td>
               <td>
@@ -4097,7 +4097,7 @@ var mappingTableLabels = {
               <td><code>object:state-changed:active</code></td>
               <td>No notification</td>
             </tr>
-              <tr id="event-aria-disabled">
+              <tr data-id="event-aria-disabled">
               <th><a class="state-reference" href="#aria-disabled"><code>aria-disabled</code></a> (state)</th>
               <td><code>EVENT_OBJECT_STATECHANGE</code></td>
               <td>
@@ -4107,7 +4107,7 @@ var mappingTableLabels = {
               <td><code>object:state-changed:enabled</code> and  <code>object:state-changed:sensitive</code></td>
               <td>No notification</td>
             </tr>
-            <tr id="event-aria-describedby">
+            <tr data-id="event-aria-describedby">
 	      <th><a class="property-reference" href="#aria-describedby"><code>aria-describedby</code></a></th>
 	      <td><code>EVENT_OBJECT_DESCRIPTIONCHANGE</code></td>
 	      <td>
@@ -4117,7 +4117,7 @@ var mappingTableLabels = {
 	      <td><code>object:property-change:accessible-description</code></td>
 	      <td>TBD</td>
             </tr>
-            <tr id="event-aria-dropeffect">
+            <tr data-id="event-aria-dropeffect">
                 <th><a class="property-reference" href="#aria-dropeffect"><code>aria-dropeffect</code></a> (property)</th>
                 <td><code>IA2_EVENT_OBJECT_ATTRIBUTE_CHANGED</code></td>
                 <td>
@@ -4127,7 +4127,7 @@ var mappingTableLabels = {
                 <td><code>object:property-change</code></td>
                 <td>No notification</td>
             </tr>
-            <tr id="event-aria-expanded">
+            <tr data-id="event-aria-expanded">
               <th><a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a> (state)</th>
               <td><code>EVENT_OBJECT_STATECHANGE</code></td>
               <td>
@@ -4139,7 +4139,7 @@ var mappingTableLabels = {
                   <code>AXRowCollapsed</code>,<br />
                   <code>AXRowCountChanged</code></td>
             </tr>
-            <tr id="event-aria-grabbed">
+            <tr data-id="event-aria-grabbed">
               <th><a class="state-reference" href="#aria-grabbed"><code>aria-grabbed</code></a> (state)</th>
               <td><p><code>EVENT_OBJECT_SELECTION</code></p>
                   <p><code>IA2_EVENT_OBJECT_ATTRIBUTE_CHANGED</code></p></td>
@@ -4150,7 +4150,7 @@ var mappingTableLabels = {
               <td><code>object:property-change</code></td>
               <td>No notification</td>
             </tr>
-            <tr id="event-aria-hidden">
+            <tr data-id="event-aria-hidden">
               <th><a class="state-reference" href="#aria-hidden"><code>aria-hidden</code></a> (state)</th>
               <td><code> IA2_EVENT_OBJECT_ATTRIBUTE_CHANGED</code></td>
               <td>
@@ -4162,7 +4162,7 @@ var mappingTableLabels = {
               <td><code>AXUIElementDestroyed</code>,<br />
                   <code>AXUIElementCreated</code></td>
             </tr>
-            <tr id="event-aria-invalid">
+            <tr data-id="event-aria-invalid">
               <th><a class="state-reference" href="#aria-invalid"><code>aria-invalid</code></a> (state)</th>
               <td><code>EVENT_OBJECT_STATECHANGE</code></td>
               <td>
@@ -4172,7 +4172,7 @@ var mappingTableLabels = {
               <td><code>object:state-changed:invalid_entry</code></td>
               <td><code>AXInvalidStatusChanged</code></td>
             </tr>
-            <tr id="event-aria-label">
+            <tr data-id="event-aria-label">
 	      <th><a class="property-reference" href="#aria-label"><code>aria-label</code></a> and <a class="property-reference" href="#aria-labelledby"><code>aria-labelledby</code></a></th>
 	      <td><code>EVENT_OBJECT_NAMECHANGE</code></td>
 	      <td>
@@ -4183,7 +4183,7 @@ var mappingTableLabels = {
 	      <td><code>object:property-change:accessible-name</code></td>
 	      <td>TBD</td>
             </tr>
-            <tr id="event-aria-pressed">
+            <tr data-id="event-aria-pressed">
               <th><a class="state-reference" href="#aria-pressed"><code>aria-pressed</code></a> (state)</th>
               <td><code>EVENT_OBJECT_STATECHANGE</code></td>
               <td>
@@ -4193,7 +4193,7 @@ var mappingTableLabels = {
               <td><code>object:state-changed:pressed</code></td>
               <td>No notification</td>
             </tr>
-            <tr id="event-aria-readonly">
+            <tr data-id="event-aria-readonly">
               <th><a class="property-reference" href="#aria-readonly"><code>aria-readonly</code></a></th>
               <td><code>EVENT_OBJECT_STATECHANGE</code></td>
               <td>
@@ -4203,7 +4203,7 @@ var mappingTableLabels = {
               <td><code>object:state-changed:readonly</code></td>
               <td>No notification</td>
             </tr>
-            <tr id="event-aria-required">
+            <tr data-id="event-aria-required">
               <th><a class="property-reference" href="#aria-required"><code>aria-required</code></a></th>
               <td><code>EVENT_OBJECT_STATECHANGE</code></td>
               <td>
@@ -4213,14 +4213,14 @@ var mappingTableLabels = {
               <td><code>object:state-changed:required</code></td>
               <td>No notification</td>
             </tr>
-            <tr id="event-aria-selected">
+            <tr data-id="event-aria-selected">
               <th><a class="property-reference" href="#aria-selected"><code>aria-selected</code></a> (state)</th>
               <td>See section <a href="#mapping_events_selection">Selection</a> for details.  </td>
               <td>See section <a href="#mapping_events_selection">Selection</a> for details.  </td>
               <td>See section <a href="#mapping_events_selection">Selection</a> for details.  </td>
               <td>See section <a href="#mapping_events_selection">Selection</a> for details.  </td>
             </tr>
-            <tr id="event-aria-valuenow">
+            <tr data-id="event-aria-valuenow">
               <th><a class="property-reference" href="#aria-valuenow"><code>aria-valuenow</code></a></th>
               <td><code>EVENT_OBJECT_VALUECHANGE</code></td>
               <td>
@@ -4230,7 +4230,7 @@ var mappingTableLabels = {
               <td><code>object:property-change:accessible-value</code></td>
               <td><code>AXValueChanged</code></td>
             </tr>
-            <tr id="event-aria-valuetext">
+            <tr data-id="event-aria-valuetext">
               <th><a class="property-reference" href="#aria-valuetext"><code>aria-valuetext</code></a></th>
               <td><code>EVENT_OBJECT_VALUECHANGE</code></td>
               <td>

--- a/out.html
+++ b/out.html
@@ -1,0 +1,5104 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US"><head>
+<meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+<meta name="generator" content="ReSpec 28.2.2">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<style>
+.issue-label{text-transform:initial}
+.warning>p:first-child{margin-top:0}
+.warning{padding:.5em;border-left-width:.5em;border-left-style:solid}
+span.warning{padding:.1em .5em .15em}
+.issue.closed span.issue-number{text-decoration:line-through}
+.warning{border-color:#f11;border-width:.2em;border-style:solid;background:#fbe9e9}
+.warning-title:before{content:"⚠";font-size:1.3em;float:left;padding-right:.3em;margin-top:-.3em}
+li.task-list-item{list-style:none}
+input.task-list-item-checkbox{margin:0 .35em .25em -1.6em;vertical-align:middle}
+.issue a.respec-gh-label{padding:5px;margin:0 2px 0 2px;font-size:10px;text-transform:none;text-decoration:none;font-weight:700;border-radius:4px;position:relative;bottom:2px;border:none;display:inline-block}
+</style>
+<style>
+dfn{cursor:pointer}
+.dfn-panel{position:absolute;z-index:35;min-width:300px;max-width:500px;padding:.5em .75em;margin-top:.6em;font:small Helvetica Neue,sans-serif,Droid Sans Fallback;background:#fff;color:#000;box-shadow:0 1em 3em -.4em rgba(0,0,0,.3),0 0 1px 1px rgba(0,0,0,.05);border-radius:2px}
+.dfn-panel:not(.docked)>.caret{position:absolute;top:-9px}
+.dfn-panel:not(.docked)>.caret::after,.dfn-panel:not(.docked)>.caret::before{content:"";position:absolute;border:10px solid transparent;border-top:0;border-bottom:10px solid #fff;top:0}
+.dfn-panel:not(.docked)>.caret::before{border-bottom:9px solid #a2a9b1}
+.dfn-panel *{margin:0}
+.dfn-panel b{display:block;color:#000;margin-top:.25em}
+.dfn-panel ul a[href]{color:#333}
+.dfn-panel>div{display:flex}
+.dfn-panel a.self-link{font-weight:700;margin-right:auto}
+.dfn-panel .marker{padding:.1em;margin-left:.5em;border-radius:.2em;text-align:center;white-space:nowrap;font-size:90%;color:#040b1c}
+.dfn-panel .marker.dfn-exported{background:#d1edfd;box-shadow:0 0 0 .125em #1ca5f940}
+.dfn-panel .marker.idl-block{background:#8ccbf2;box-shadow:0 0 0 .125em #0670b161}
+.dfn-panel a:not(:hover){text-decoration:none!important;border-bottom:none!important}
+.dfn-panel a[href]:hover{border-bottom-width:1px}
+.dfn-panel ul{padding:0}
+.dfn-panel li{margin-left:1em}
+.dfn-panel.docked{position:fixed;left:.5em;top:unset;bottom:2em;margin:0 auto;max-width:calc(100vw - .75em * 2 - .5em - .2em * 2);max-height:30vh;overflow:auto}
+</style>
+
+<title>Core Accessibility API Mappings 1.2</title>
+
+
+<script src="https://www.w3.org/scripts/jquery/1.11.3/jquery.min.js"></script>
+
+<style id="respec-mainstyle">
+@keyframes pop{
+0%{transform:scale(1,1)}
+25%{transform:scale(1.25,1.25);opacity:.75}
+100%{transform:scale(1,1)}
+}
+:is(h1,h2,h3,h4,h5,h6,a) abbr{border:none}
+dfn{font-weight:700}
+a.internalDFN{color:inherit;border-bottom:1px solid #99c;text-decoration:none}
+a.externalDFN{color:inherit;border-bottom:1px dotted #ccc;text-decoration:none}
+a.bibref{text-decoration:none}
+.respec-offending-element:target{animation:pop .25s ease-in-out 0s 1}
+.respec-offending-element,a[href].respec-offending-element{text-decoration:red wavy underline}
+@supports not (text-decoration:red wavy underline){
+.respec-offending-element:not(pre){display:inline-block}
+.respec-offending-element{background:url(data:image/gif;base64,R0lGODdhBAADAPEAANv///8AAP///wAAACwAAAAABAADAEACBZQjmIAFADs=) bottom repeat-x}
+}
+#references :target{background:#eaf3ff;animation:pop .4s ease-in-out 0s 1}
+cite .bibref{font-style:normal}
+code{color:#c63501}
+th code{color:inherit}
+a[href].orcid{padding-left:4px;padding-right:4px}
+a[href].orcid>svg{margin-bottom:-2px}
+.toc a,.tof a{text-decoration:none}
+a .figno,a .secno{color:#000}
+ol.tof,ul.tof{list-style:none outside none}
+.caption{margin-top:.5em;font-style:italic}
+table.simple{border-spacing:0;border-collapse:collapse;border-bottom:3px solid #005a9c}
+.simple th{background:#005a9c;color:#fff;padding:3px 5px;text-align:left}
+.simple th a{color:#fff;padding:3px 5px;text-align:left}
+.simple th[scope=row]{background:inherit;color:inherit;border-top:1px solid #ddd}
+.simple td{padding:3px 10px;border-top:1px solid #ddd}
+.simple tr:nth-child(even){background:#f0f6ff}
+.section dd>p:first-child{margin-top:0}
+.section dd>p:last-child{margin-bottom:0}
+.section dd{margin-bottom:1em}
+.section dl.attrs dd,.section dl.eldef dd{margin-bottom:0}
+#issue-summary>ul{column-count:2}
+#issue-summary li{list-style:none;display:inline-block}
+details.respec-tests-details{margin-left:1em;display:inline-block;vertical-align:top}
+details.respec-tests-details>*{padding-right:2em}
+details.respec-tests-details[open]{z-index:999999;position:absolute;border:thin solid #cad3e2;border-radius:.3em;background-color:#fff;padding-bottom:.5em}
+details.respec-tests-details[open]>summary{border-bottom:thin solid #cad3e2;padding-left:1em;margin-bottom:1em;line-height:2em}
+details.respec-tests-details>ul{width:100%;margin-top:-.3em}
+details.respec-tests-details>li{padding-left:1em}
+a[href].self-link:hover{opacity:1;text-decoration:none;background-color:transparent}
+h2,h3,h4,h5,h6{position:relative}
+aside.example .marker>a.self-link{color:inherit}
+:is(h2,h3,h4,h5,h6)>a.self-link{border:none;color:inherit;font-size:83%;height:2em;left:-1.6em;opacity:.5;position:absolute;text-align:center;text-decoration:none;top:0;transition:opacity .2s;width:2em}
+:is(h2,h3,h4,h5,h6)>a.self-link::before{content:"§";display:block}
+@media (max-width:767px){
+dd{margin-left:0}
+:is(h2,h3,h4,h5,h6)>a.self-link{left:auto;top:auto}
+}
+@media print{
+.removeOnSave{display:none}
+}
+</style>
+
+
+
+
+<script src="common/script/mapping-tables.js"></script>
+
+
+<link href="common/css/mapping-tables.css" rel="stylesheet" type="text/css">
+
+<link href="common/css/common.css" rel="stylesheet" type="text/css">
+
+<link href="css/core-aam.css" rel="stylesheet" type="text/css">
+
+
+
+<script src="common/script/jquery.details.min.js"></script>
+
+<script type="text/javascript">
+
+var mappingTableLabels = {
+  viewByTable: "View as a single table",
+  expand: "Expand all",
+  collapse: "Collapse all",
+  showHideCols: "Show/Hide Columns:",
+  showActionText: "Show",
+  hideActionText: "Hide",
+  showToolTipText: "Show column",
+  hideToolTipText: "Hide column",
+
+  // map where keys are @id of associated mapping table:
+  viewByLabels: {
+    "role-mapping-table": "View by roles",
+    "state-property-mapping-table": "View by state/property",
+    "event-mapping-table": "View by state/property"
+  }
+}
+</script>
+
+
+<meta name="description" content="This document describes how user agents should expose semantics of web content languages to accessibility APIs. This helps users with disabilities to obtain and interact with information using assistive technologies. Documenting these mappings promotes interoperable exposure of roles, states, properties, and events implemented by accessibility APIs and helps to ensure that this information appears in a manner consistent with author intent.">
+<style>
+var{position:relative;cursor:pointer}
+var[data-type]::after,var[data-type]::before{position:absolute;left:50%;top:-6px;opacity:0;transition:opacity .4s;pointer-events:none}
+var[data-type]::before{content:"";transform:translateX(-50%);border-width:4px 6px 0 6px;border-style:solid;border-color:transparent;border-top-color:#000}
+var[data-type]::after{content:attr(data-type);transform:translateX(-50%) translateY(-100%);background:#000;text-align:center;font-family:"Dank Mono","Fira Code",monospace;font-style:normal;padding:6px;border-radius:3px;color:#daca88;text-indent:0;font-weight:400}
+var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
+</style>
+<script id="initialUserConfig" type="application/json">{
+  "github": "w3c/core-aam",
+  "doJsonLd": true,
+  "lint": true,
+  "specStatus": "ED",
+  "shortName": "core-aam-1.2",
+  "copyrightStart": "2014",
+  "license": "document",
+  "prevRecURI": "https://www.w3.org/TR/core-aam-1.1/",
+  "edDraftURI": "https://w3c.github.io/core-aam/",
+  "editors": [
+    {
+      "name": "Joanmarie Diggs",
+      "company": "Igalia, S.L.",
+      "companyURL": "https://www.igalia.com",
+      "w3cid": 68182
+    },
+    {
+      "name": "Alexander Surkov",
+      "company": "Igalia, S.L.",
+      "companyURL": "https://www.igalia.com",
+      "w3cid": 51089
+    },
+    {
+      "name": "Michael Cooper",
+      "company": "W3C",
+      "companyURL": "https://www.w3.org",
+      "w3cid": 34017
+    }
+  ],
+  "formerEditors": [
+    {
+      "name": "Richard Schwerdtfeger",
+      "company": "Knowbility",
+      "companyURL": "https://www.knowbility.org/",
+      "w3cid": 2460,
+      "note": "Editor until October 2017"
+    },
+    {
+      "name": "Joseph Scheuhammer",
+      "company": "Inclusive Design Research Centre, OCAD University",
+      "companyURL": "http://idrc.ocad.ca",
+      "w3cid": 42279,
+      "note": "Editor until May 2017"
+    },
+    {
+      "name": "Andi Snow-Weaver",
+      "company": "IBM",
+      "companyURL": "http://www.ibm.com",
+      "w3cid": 35445,
+      "note": "Editor until December 2012"
+    },
+    {
+      "name": "Aaron Leventhal",
+      "company": "IBM",
+      "companyURL": "http://www.ibm.com",
+      "w3cid": 34329,
+      "note": "Editor until January 2009"
+    }
+  ],
+  "authors": [
+    {
+      "name": "Melanie Richards",
+      "company": "Microsoft Corp.",
+      "companyURL": "https://microsoft.com/",
+      "note": "UIA",
+      "w3cid": 96078
+    },
+    {
+      "name": "James Craig",
+      "company": "Apple, Inc.",
+      "companyURL": "https://apple.com/accessibility",
+      "note": "AX API",
+      "w3cid": 42459
+    },
+    {
+      "name": "Joanmarie Diggs",
+      "company": "Igalia, S.L.",
+      "companyURL": "https://www.igalia.com",
+      "w3cid": 68182,
+      "note": "ATK / AT-SPI"
+    },
+    {
+      "name": "Alexander Surkov",
+      "company": "Igalia, S.L.",
+      "companyURL": "https://www.igalia.com",
+      "note": "MSAA, IAccessible2",
+      "w3cid": 51089
+    }
+  ],
+  "group": "aria",
+  "tocIntroductory": true,
+  "ariaSpecURLs": {
+    "ED": "https://w3c.github.io/aria/",
+    "WD": "https://www.w3.org/TR/wai-aria-1.1/",
+    "CR": "https://www.w3.org/TR/wai-aria-1.1/",
+    "PR": "https://www.w3.org/TR/wai-aria-1.1/",
+    "REC": "https://www.w3.org/TR/wai-aria/"
+  },
+  "accNameURLs": {
+    "ED": "https://w3c.github.io/accname/",
+    "WD": "https://www.w3.org/TR/accname-aam-1.1/",
+    "FPWD": "https://www.w3.org/TR/accname-aam-1.1/",
+    "CR": "https://www.w3.org/TR/accname-aam-1.1/",
+    "PR": "https://www.w3.org/TR/accname-aam-1.1/",
+    "REC": "https://www.w3.org/TR/accname-aam-1.1/"
+  },
+  "preProcess": [
+    null,
+    null
+  ],
+  "postProcess": [
+    null
+  ],
+  "xref": [
+    "core-aam",
+    "accname",
+    "wai-aria"
+  ],
+  "localBiblio": {
+    "ACCNAME-AAM": {
+      "aliasOf": "ACCNAME-AAM-1.1"
+    },
+    "ARIA-PRACTICES": {
+      "aliasOf": "WAI-ARIA-PRACTICES-1.1"
+    },
+    "CORE-AAM": {
+      "aliasOf": "CORE-AAM-1.1"
+    },
+    "DPUB-ARIA": {
+      "aliasOf": "DPUB-ARIA-1.0"
+    },
+    "GRAPHICS-ARIA": {
+      "aliasOf": "GRAPHICS-ARIA-1.0"
+    },
+    "GRAPHICS-AAM": {
+      "aliasOf": "GRAPHICS-AAM-1.0"
+    },
+    "EPUB-Content": {
+      "href": "http://www.idpf.org/epub/31/spec/epub-contentdocs.html",
+      "title": "EPUB Content Documents 3.1",
+      "publisher": "IDPF"
+    },
+    "HTML-AAM": {
+      "aliasOf": "HTML-AAM-1.0"
+    },
+    "MathML-Core": {
+      "href": "https://mathml-refresh.github.io/mathml-core/",
+      "title": "MathML Core",
+      "authors": [
+        "David Carlisle",
+        "Frédéric Wang"
+      ]
+    },
+    "SVG-AAM": {
+      "aliasOf": "SVG-AAM-1.0"
+    },
+    "SVG1": {
+      "aliasOf": "SVG"
+    },
+    "WAI-ARIA": {
+      "aliasOf": "WAI-ARIA-1.1"
+    }
+  },
+  "publishISODate": "2022-01-19T00:00:00.000Z",
+  "generatedSubtitle": "Editor's Draft 19 January 2022"
+}</script>
+<link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED"></head>
+<body class="h-entry" data-cite="core-aam accname wai-aria"><div class="head">
+    <a class="logo" href="https://www.w3.org/"><img crossorigin="" alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
+  </a> <h1 id="title" class="title">Core Accessibility API Mappings 1.2</h1>
+    
+    <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">W3C Editor's Draft</a> <time class="dt-published" datetime="2022-01-19">19 January 2022</time></p>
+    <details open="">
+      <summary>More details about this document</summary>
+      <dl>
+        <dt>This version:</dt><dd>
+                <a class="u-url" href="https://w3c.github.io/core-aam/">https://w3c.github.io/core-aam/</a>
+              </dd><dt>Latest published version:</dt><dd>
+                <a href="https://www.w3.org/TR/core-aam-1.2/">https://www.w3.org/TR/core-aam-1.2/</a>
+              </dd>
+        <dt>Latest editor's draft:</dt><dd><a href="https://w3c.github.io/core-aam/">https://w3c.github.io/core-aam/</a></dd>
+        <dt>History:</dt><dd>
+      <a href="https://www.w3.org/standards/history/core-aam-1.2">https://www.w3.org/standards/history/core-aam-1.2</a>
+    </dd><dd>
+        <a href="https://github.com/w3c/core-aam/commits/">Commit history</a>
+      </dd>
+        
+        
+        
+        
+        <dt>Latest Recommendation:</dt><dd><a href="https://www.w3.org/TR/core-aam-1.1/">https://www.w3.org/TR/core-aam-1.1/</a></dd>
+        <dt>Editors:</dt>
+        <dd class="editor p-author h-card vcard" data-editor-id="68182">
+    <span class="p-name fn">Joanmarie Diggs</span> (<a class="p-org org h-org" href="https://www.igalia.com">Igalia, S.L.</a>)
+  </dd><dd class="editor p-author h-card vcard" data-editor-id="51089">
+    <span class="p-name fn">Alexander Surkov</span> (<a class="p-org org h-org" href="https://www.igalia.com">Igalia, S.L.</a>)
+  </dd><dd class="editor p-author h-card vcard" data-editor-id="34017">
+    <span class="p-name fn">Michael Cooper</span> (<a class="p-org org h-org" href="https://www.w3.org">W3C</a>)
+  </dd>
+        <dt>
+                Former editors:
+              </dt><dd class="editor p-author h-card vcard" data-editor-id="2460">
+    <span class="p-name fn">Richard Schwerdtfeger</span> (<a class="p-org org h-org" href="https://www.knowbility.org/">Knowbility</a>) (Editor until October 2017)
+  </dd><dd class="editor p-author h-card vcard" data-editor-id="42279">
+    <span class="p-name fn">Joseph Scheuhammer</span> (<a class="p-org org h-org" href="http://idrc.ocad.ca">Inclusive Design Research Centre, OCAD University</a>) (Editor until May 2017)
+  </dd><dd class="editor p-author h-card vcard" data-editor-id="35445">
+    <span class="p-name fn">Andi Snow-Weaver</span> (<a class="p-org org h-org" href="http://www.ibm.com">IBM</a>) (Editor until December 2012)
+  </dd><dd class="editor p-author h-card vcard" data-editor-id="34329">
+    <span class="p-name fn">Aaron Leventhal</span> (<a class="p-org org h-org" href="http://www.ibm.com">IBM</a>) (Editor until January 2009)
+  </dd>
+        <dt>Platform Mapping Maintainers:</dt><dd class="editor p-author h-card vcard" data-editor-id="96078">
+    <span class="p-name fn">Melanie Richards</span> (<a class="p-org org h-org" href="https://microsoft.com/">Microsoft Corp.</a>) (UIA)
+  </dd><dd class="editor p-author h-card vcard" data-editor-id="42459">
+    <span class="p-name fn">James Craig</span> (<a class="p-org org h-org" href="https://apple.com/accessibility">Apple, Inc.</a>) (AX API)
+  </dd><dd class="editor p-author h-card vcard" data-editor-id="68182">
+    <span class="p-name fn">Joanmarie Diggs</span> (<a class="p-org org h-org" href="https://www.igalia.com">Igalia, S.L.</a>) (ATK / AT-SPI)
+  </dd><dd class="editor p-author h-card vcard" data-editor-id="51089">
+    <span class="p-name fn">Alexander Surkov</span> (<a class="p-org org h-org" href="https://www.igalia.com">Igalia, S.L.</a>) (MSAA, IAccessible2)
+  </dd>
+        <dt>Feedback:</dt><dd>
+        <a href="https://github.com/w3c/core-aam/">GitHub w3c/core-aam</a>
+        (<a href="https://github.com/w3c/core-aam/pulls/">pull requests</a>,
+        <a href="https://github.com/w3c/core-aam/issues/new/choose">new issue</a>,
+        <a href="https://github.com/w3c/core-aam/issues/">open issues</a>)
+      </dd>
+        
+        
+      </dl>
+    </details>
+    
+    
+    <p class="copyright">
+    <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a>
+    ©
+    2014-2022
+    
+    <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
+    <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>,
+    <a href="https://ev.buaa.edu.cn/">Beihang</a>). W3C
+    <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+    <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+    <a rel="license" href="https://www.w3.org/Consortium/Legal/copyright-documents" title="W3C Document License">document use</a> rules apply.
+  </p>
+    <hr title="Separator for header">
+  </div>
+<section id="abstract" class="introductory"><h2 id="abstract-0">Abstract<a class="self-link" href="#abstract" aria-label="Permalink for Section"></a></h2>
+	<p>This document describes how <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria-1.2/#dfn-user-agent">user agents</a> should expose semantics of web content languages to <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria-1.2/#dfn-accessibility-api">accessibility <abbr title="Application Programming Interfaces">APIs</abbr></a>. This helps users with disabilities to obtain and interact with information using <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria-1.2/#dfn-assistive-technology">assistive technologies</a>. Documenting these mappings promotes interoperable exposure of roles, states, properties, and events implemented by accessibility <abbr title="Application Programming Interfaces">APIs</abbr> and helps to ensure that this information appears in a manner consistent with author intent. </p>
+			<p>This Core Accessibility <abbr title="Application Programming Interface">API</abbr> Mappings specification defines support that applies across multiple content technologies, including general keyboard navigation support and mapping of general-purpose <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria-1.2/#dfn-role">roles</a>, states, and <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria-1.2/#dfn-property">properties</a> provided in Web content via <cite><a href="http://www.w3.org/TR/wai-aria-1.2/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr></a></cite> [<cite><a class="bibref" data-link-type="biblio" href="#bib-wai-aria-1.2" title="Accessible Rich Internet Applications (WAI-ARIA) 1.2">WAI-ARIA-1.2</a></cite>]. Other Accessibility <abbr title="Application Programming Interface">API</abbr> Mappings specifications depend on and extend this Core specification for specific technologies, including native technology features and <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> extensions. This document updates and will eventually supersede the guidance in the <a href="http://www.w3.org/TR/core-aam-1.1/">Core Accessibility <abbr title="Application Programming Interface">API</abbr> Mappings 1.1</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-core-aam-1.1" title="Core Accessibility API Mappings 1.1">CORE-AAM-1.1</a></cite>] <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation. It is part of the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> suite described in the <a href="http://www.w3.org/WAI/intro/aria.php"><abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Overview</a>.</p>
+</section>
+<section id="sotd" class="introductory"><h2 id="status-of-this-document">Status of This Document<a class="self-link" href="#sotd" aria-label="Permalink for Section"></a></h2><p><em>This section describes the status of this
+      document at the time of its publication. A list of current <abbr title="World Wide Web Consortium">W3C</abbr>
+      publications and the latest revision of this technical report can be found
+      in the <a href="https://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at
+      https://www.w3.org/TR/.</em></p>
+	<p>The Accessible Rich Internet Applications Working Group seeks feedback on any aspect of the specification. When submitting feedback, please consider issues in the context of the companion documents. To comment, <a href="https://github.com/w3c/core-aam/issues/new">file an issue in the <abbr title="World Wide Web Consortium">W3C</abbr> core-aam GitHub repository</a>. If this is not feasible, send email to <a href="mailto:public-aria@w3.org?subject=Comment%20on%20Core-AAM%201.2">public-aria@w3.org</a> (<a href="http://lists.w3.org/Archives/Public/public-aria/">comment archive</a>). In-progress updates to the document may be viewed in the <a href="http://w3c.github.io/core-aam/">publicly visible editors' draft</a>.</p>
+<p>
+    This document was published by the <a href="https://www.w3.org/groups/wg/aria">Accessible Rich Internet Applications Working Group</a> as
+    an Editor's Draft. 
+  </p><p>Publication as an Editor's Draft does not
+  imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members. </p><p>
+    This is a draft document and may be updated, replaced or obsoleted by other
+    documents at any time. It is inappropriate to cite this document as other
+    than work in progress.
+    
+  </p><p>
+    
+        This document was produced by a group
+        operating under the
+        <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/">1 August 2017 <abbr title="World Wide Web Consortium">W3C</abbr> Patent
+          Policy</a>.
+      
+    
+                <abbr title="World Wide Web Consortium">W3C</abbr> maintains a
+                <a rel="disclosure" href="https://www.w3.org/groups/wg/aria/ipr">public list of any patent disclosures</a>
+          made in connection with the deliverables of
+          the group; that page also includes
+          instructions for disclosing a patent. An individual who has actual
+          knowledge of a patent which the individual believes contains
+          <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#def-essential">Essential Claim(s)</a>
+          must disclose the information in accordance with
+          <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+        
+  </p><p>
+                  This document is governed by the
+                  <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
+                </p></section><nav id="toc"><h2 class="introductory" id="table-of-contents">Table of Contents</h2><ol class="toc"><li class="tocline"><a class="tocxref" href="#abstract">Abstract</a></li><li class="tocline"><a class="tocxref" href="#sotd">Status of This Document</a></li><li class="tocline"><a class="tocxref" href="#intro"><bdi class="secno">1. </bdi>Introduction</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#intro_aapi"><bdi class="secno">1.1 </bdi>Accessibility <abbr title="Application Programming Interfaces">APIs</abbr> </a></li><li class="tocline"><a class="tocxref" href="#comparing-accessibility-apis"><bdi class="secno">1.2 </bdi>Comparing Accessibility <abbr title="Application Programming Interfaces">APIs</abbr></a><ol class="toc"><li class="tocline"><a class="tocxref" href="#atk-at-spi"><bdi class="secno">1.2.1 </bdi><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="assistive technology">AT</abbr>-SPI</a></li><li class="tocline"><a class="tocxref" href="#uia-ui-automation"><bdi class="secno">1.2.2 </bdi><abbr title="User Interface Automation">UIA</abbr> (<abbr title="user interface">UI</abbr> Automation)</a></li><li class="tocline"><a class="tocxref" href="#accessible-names-and-descriptions"><bdi class="secno">1.2.3 </bdi>Accessible Names and Descriptions</a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#conformance"><bdi class="secno">2. </bdi>Conformance</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#rfc-2119-keywords"><bdi class="secno">2.1 </bdi>RFC-2119 Keywords</a></li><li class="tocline"><a class="tocxref" href="#normative-and-informative-sections"><bdi class="secno">2.2 </bdi>Normative and Informative Sections</a></li><li class="tocline"><a class="tocxref" href="#features-deprecated-in-wai-aria"><bdi class="secno">2.3 </bdi>Features Deprecated in <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr></a></li></ol></li><li class="tocline"><a class="tocxref" href="#glossary"><bdi class="secno">3. </bdi>Important Terms</a></li><li class="tocline"><a class="tocxref" href="#mapping"><bdi class="secno">4. </bdi>Mapping <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> to Accessibility <abbr title="Application Programming Interfaces">APIs</abbr></a><ol class="toc"><li class="tocline"><a class="tocxref" href="#mapping_general"><bdi class="secno">4.1 </bdi>General rules for exposing <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> semantics</a></li><li class="tocline"><a class="tocxref" href="#mapping_conflicts"><bdi class="secno">4.2 </bdi>Conflicts between native markup semantics and <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr></a></li><li class="tocline"><a class="tocxref" href="#mapping_nodirect"><bdi class="secno">4.3 </bdi>Exposing attributes that do not directly map to accessibility <abbr title="application programming interface">API</abbr> properties</a></li><li class="tocline"><a class="tocxref" href="#mapping_role"><bdi class="secno">4.4 </bdi>Role mapping</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#roleMappingGeneralRules"><bdi class="secno">4.4.1 </bdi>General rules</a></li><li class="tocline"><a class="tocxref" href="#mapping_role_table"><bdi class="secno">4.4.2 </bdi>Role Mapping Table</a></li></ol></li><li class="tocline"><a class="tocxref" href="#mapping_state-property"><bdi class="secno">4.5 </bdi>State and Property Mapping</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#statePropertyMappingGeneralRules"><bdi class="secno">4.5.1 </bdi>General rules</a></li><li class="tocline"><a class="tocxref" href="#mapping_state-property_table"><bdi class="secno">4.5.2 </bdi>State and Property Mapping Table</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#not_mapped"><bdi class="secno">4.5.2.1 </bdi>Not Mapped</a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#mapping_additional"><bdi class="secno">4.6 </bdi>Special Processing Requiring Additional Computation</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#mapping_additional_nd"><bdi class="secno">4.6.1 </bdi>Name and Description</a></li><li class="tocline"><a class="tocxref" href="#mapping_additional_relations"><bdi class="secno">4.6.2 </bdi>Relations</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#mapping_additional_relations_reverse_relations"><bdi class="secno">4.6.2.1 </bdi>Reverse Relations</a></li><li class="tocline"><a class="tocxref" href="#mapping_additional_relations_implied"><bdi class="secno">4.6.2.2 </bdi>Implied reverse relations</a></li></ol></li><li class="tocline"><a class="tocxref" href="#mapping_additional_position"><bdi class="secno">4.6.3 </bdi>Group Position</a></li></ol></li><li class="tocline"><a class="tocxref" href="#mapping_actions"><bdi class="secno">4.7 </bdi>Actions</a></li><li class="tocline"><a class="tocxref" href="#mapping_events"><bdi class="secno">4.8 </bdi>Events</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#mapping_events_state-change"><bdi class="secno">4.8.1 </bdi>State and Property Change Events</a></li><li class="tocline"><a class="tocxref" href="#mapping_events_visibility"><bdi class="secno">4.8.2 </bdi>Changes to document content or node visibility</a></li><li class="tocline"><a class="tocxref" href="#focus_state_event_table"><bdi class="secno">4.8.3 </bdi>Focus Changes</a></li><li class="tocline"><a class="tocxref" href="#mapping_events_selection"><bdi class="secno">4.8.4 </bdi>Selection</a></li><li class="tocline"><a class="tocxref" href="#mapping_events_menus"><bdi class="secno">4.8.5 </bdi>Special Events for Menus</a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#changelog"><bdi class="secno">A. </bdi>Change Log</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#substantive-changes-since-the-last-public-working-draft"><bdi class="secno">A.1 </bdi>Substantive changes since the last public working draft</a></li><li class="tocline"><a class="tocxref" href="#substantive-changes-since-the-core-accessibility-api-mappings-1-1-recommendation"><bdi class="secno">A.2 </bdi>Substantive changes since the <span class="formerLink">Core Accessibility <abbr title="Application Programming Interface">API</abbr> Mappings 1.1 Recommendation</span></a></li></ol></li><li class="tocline"><a class="tocxref" href="#acknowledgements"><bdi class="secno">B. </bdi>Acknowledgments</a></li><li class="tocline"><a class="tocxref" href="#references"><bdi class="secno">C. </bdi>References</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#normative-references"><bdi class="secno">C.1 </bdi>Normative references</a></li><li class="tocline"><a class="tocxref" href="#informative-references"><bdi class="secno">C.2 </bdi>Informative references</a></li></ol></li></ol></nav>
+<section id="intro" class="informative">
+	<h2 id="x1-introduction"><bdi class="secno">1. </bdi>Introduction<a class="self-link" href="#intro" aria-label="Permalink for Section 1."></a></h2><p><em>This section is non-normative.</em></p>
+	<p>The Core Accessibility <abbr title="Application Programming Interface">API</abbr> Mappings specifies how <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria-1.2/#dfn-role">roles</a>, <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria-1.2/#dfn-state">states</a>, and <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria-1.2/#dfn-property">properties</a> are expected to be exposed by user agents via platform accessibility <abbr title="Application Programming Interfaces">APIs</abbr>. It is part of a set of resources that define and support the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> specification which includes the following documents:</p>
+	<ul>
+          <li><cite><a class="specref" href="https://w3c.github.io/aria/">Accessible Rich Internet Applications (<abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr>) 1.2</a></cite> [<cite><a class="bibref" data-link-type="biblio" href="#bib-wai-aria-1.2" title="Accessible Rich Internet Applications (WAI-ARIA) 1.2">WAI-ARIA-1.2</a></cite>], a planned <abbr title="World Wide Web Consortium">W3C</abbr> recommendation, defines the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> standard.</li>
+          <li><cite><a href="http://www.w3.org/TR/wai-aria-practices/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices Guide</a></cite> [<cite><a class="bibref" data-link-type="biblio" href="#bib-wai-aria-practices-1.2" title="WAI-ARIA Authoring Practices 1.2">WAI-ARIA-PRACTICES-1.2</a></cite>], a planned <abbr title="World Wide Web Consortium">W3C</abbr> Working Group Note, describes how web content developers can develop accessible rich internet applications using <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>. It provides detailed advice and examples directed primarily to web application developers, yet also useful to user agent and developers of assistive technologies.</li>
+          <li><cite><a href="http://www.w3.org/TR/wai-aria-roadmap/">Roadmap for Accessible Rich Internet Applications (<abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Roadmap)</a></cite> [<cite><a class="bibref" data-link-type="biblio" href="#bib-wai-aria-roadmap" title="Roadmap for Accessible Rich Internet Applications (WAI-ARIA Roadmap)">WAI-ARIA-ROADMAP</a></cite>], a planned <abbr title="World Wide Web Consortium">W3C</abbr> Working Group Note, defines the path to make rich web content accessible, including steps already taken, remaining future steps, and a time line.</li>
+	</ul>
+	<p>For an introduction to <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>, see the <a href="http://www.w3.org/WAI/intro/aria.php"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Overview</a>.</p>
+	  <section id="intro_aapi">
+	    <h3 id="x1-1-accessibility-apis"><bdi class="secno">1.1 </bdi>Accessibility <abbr title="Application Programming Interfaces">APIs</abbr> <a class="self-link" href="#intro_aapi" aria-label="Permalink for Section 1.1"></a></h3>
+            <p><a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessibility-api">Accessibility <abbr title="Application Programming Interfaces">APIs</abbr></a> make it possible to communicate accessibility information about user interfaces to assistive technologies. This information includes:</p>
+            <ol>
+              <li>Descriptive properties (role, name, value, position, etc.)</li>
+              <li>Transient states (pressed, focused, etc.)</li>
+              <li>Events (text changed, button was clicked, checkbox was toggled)</li>
+              <li>Actions the user might take (click, check/toggle, drag, etc.)</li>
+              <li>Relationships (parent/child, description/described object, previous object/next object, etc.)</li>
+              <li>Textual content</li>
+            </ol>
+            <p>Accessibility <abbr title="Application Programming Interfaces">APIs</abbr> covered by this specification are:</p>
+	    <ul>
+              <li><abbr title="Microsoft Active Accessibility">MSAA</abbr> with <cite><a href="http://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2">IAccessible2 1.3</a></cite> [<cite><a class="bibref" data-link-type="biblio" href="#bib-iaccessible2" title="IAccessible2">IAccessible2</a></cite>]</li>
+              <li><cite><a href="https://msdn.microsoft.com/en-us/library/ee684013%28VS.85%29.aspx">User Interface Automation</a></cite> [<cite><a class="bibref" data-link-type="biblio" href="#bib-ui-automation" title="UI Automation">UI-AUTOMATION</a></cite>]</li>
+	      <li><cite><a href="https://developer.gnome.org/atk/stable/"><abbr title="Accessibility Toolkit">ATK</abbr> - Accessibility Toolkit</a></cite> [<cite><a class="bibref" data-link-type="biblio" href="#bib-atk" title="ATK - Accessibility Toolkit">ATK</a></cite>] and <cite><a href="https://developer.gnome.org/libatspi/stable/">Assistive Technology Service Provider Interface</a></cite> [<cite><a class="bibref" data-link-type="biblio" href="#bib-at-spi" title="Assistive Technology Service Provider Interface">AT-SPI</a></cite>], referred to hereafter as "<abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="assistive technology">AT</abbr>-SPI"</li>
+	      <li><cite><a href="https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Protocols/NSAccessibility_Protocol/index.html">macOS Accessibility Protocol</a></cite> [<cite><a class="bibref" data-link-type="biblio" href="#bib-axapi" title="The NSAccessibility Protocol for macOS">AXAPI</a></cite>]</li>
+	    </ul>
+	    <p>The <cite><a href="http://www.w3.org/TR/wai-aria-implementation/"><abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> 1.0 User Agent Implementation Guide</a></cite> included mappings for <cite><a href="https://msdn.microsoft.com/en-us/library/windows/desktop/dd561898%28v=vs.85%29.aspx"><abbr title="User Interface Automation">UIA</abbr> Express</a>, also known as IAccessibleEx</cite>, which was implemented in Microsoft Internet Explorer 8.0 - 11. New implementations are strongly encouraged to use <cite><a href="https://msdn.microsoft.com/en-us/library/ee684013%28VS.85%29.aspx">User Interface Automation</a></cite> instead.</p>
+	    <p>If user agent developers need to expose information using other accessibility <abbr title="Application Programming Interfaces">APIs</abbr>, it is recommended that they work closely with the developer of the platform where the <abbr title="application programming interface">API</abbr> runs, and assistive technology developers on that platform.</p>
+	  </section>
+  <section id="comparing-accessibility-apis">
+      <h3 id="x1-2-comparing-accessibility-apis"><bdi class="secno">1.2 </bdi>Comparing Accessibility <abbr title="Application Programming Interfaces">APIs</abbr><a class="self-link" href="#comparing-accessibility-apis" aria-label="Permalink for Section 1.2"></a></h3>
+      <p>For various technological and historical reasons, accessibility <abbr title="Application Programming Interfaces">APIs</abbr> do not all work in the same way. In many cases, there is no simple one-to-one relationship between how each of them names or exposes roles, states, and properties to user agents. The following subsections describe a few of the distinguishing characteristics of some of the <abbr title="Application Programming Interfaces">APIs</abbr>.</p>
+      <section id="atk-at-spi">
+        <h4 id="x1-2-1-atk-at-spi"><bdi class="secno">1.2.1 </bdi><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="assistive technology">AT</abbr>-SPI<a class="self-link" href="#atk-at-spi" aria-label="Permalink for Section 1.2.1"></a></h4>
+        <p><abbr title="Microsoft Active Accessibility">MSAA</abbr>, IAccessible2, <abbr title="User Interface Automation">UIA</abbr>, and <abbr title="macOS Accessibility Protocol">AX API</abbr> each define an <abbr title="Application Programming Interface">API</abbr> that is shared by both the software application exposing information about its content and interactive components, and the user agent (assistive technology) consuming that information. Conversely, Linux/GNOME separates that shared interface into its two aspects, each represented by a different accessibility <abbr title="Application Programming Interface">API</abbr>: <abbr title="Accessibility Toolkit">ATK</abbr> or <abbr title="assistive technology">AT</abbr>-SPI.</p>
+        <p><abbr title="Accessibility Toolkit">ATK</abbr> defines an interface that is implemented by software in order to expose accessibility information, whereas <abbr title="assistive technology">AT</abbr>-SPI is a desktop service that gathers accessibility information from active applications and relays it to other interested applications, usually assistive technologies.</p>
+        <p>For example, the GNOME <abbr title="Graphical User Interface">GUI</abbr> toolkit [GTK], implements the relevant aspects of <abbr title="Accessibility Toolkit">ATK</abbr> for each widget (menu, combobox, checkbox, etc.) in order that GTK widgets expose accessibility information about themselves. <abbr title="assistive technology">AT</abbr>-SPI then acquires the information from applications built with GTK and makes it available to interested parties.</p>
+        <p><abbr title="Accessibility Toolkit">ATK</abbr> is most relevant to implementors, whereas <abbr title="assistive technology">AT</abbr>-SPI is relevant to consumers. In the context of mapping <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> roles, states and properties, user agents are implementors and use <abbr title="Accessibility Toolkit">ATK</abbr>. Assistive Technologies are consumers, and use <abbr title="assistive technology">AT</abbr>-SPI.</p>
+      </section>
+      <section id="uia-ui-automation">
+        <h4 id="x1-2-2-uia-ui-automation"><bdi class="secno">1.2.2 </bdi><abbr title="User Interface Automation">UIA</abbr> (<abbr title="user interface">UI</abbr> Automation)<a class="self-link" href="#uia-ui-automation" aria-label="Permalink for Section 1.2.2"></a></h4>
+      	<p><abbr title="user interface">UI</abbr> Automation expresses every element of the application user interface as an automation element. Automation elements form the nodes of the application accessibility tree, that can be queried, traversed and interacted with by automation clients.</p>
+      	<p>There are several concepts central to <abbr title="user interface">UI</abbr> Automation:</p>
+	<ul>
+		<li>Automation element - controls and some application content are presented as automation elements.</li>
+		<li>Element properties - Automation elements have several common properties describing native framework element characteristics in an agnostic way that all automation clients can understand. There are several ways to access element property values, described below.</li>
+		<li>Control Patterns - Some common interactivity in different frameworks is expressed as control patterns in <abbr title="User Interface Automation">UIA</abbr>, allowing different automation clients to interact with controls using common programmatic interfaces.</li>
+		<li>Events - Similar to other accessibility <abbr title="Application Programming Interfaces">APIs</abbr>, automation elements support various events that allow automation providers to notify clients on important state changes.</li>
+      	</ul>
+      	<p>All automation elements inherit from the <code>IUIAutomationElement</code> interface and all properties that are not specific to a particular control pattern can be queried through that interface. There are several ways to access <abbr title="user interface">UI</abbr> Automation element properties:</p>
+	<ul>
+		<li>Direct property accessors to the current values - <code>Current{PropertyName}</code>, e.g. <code>IUIAutomationElement::CurrentName</code> for the <code>Name</code> property</li>
+		<li>Cached property accessors - <code>Cached{PropertyName}</code>, e.g. <code>IUIAutomationElement::CachedName</code> for the <code>Name</code> property. Using cached values is preferred when providers and clients are used in remote environments.</li>
+		<li><code>GetCurrentPropertyValue</code> and passing the <abbr title="User Interface Automation">UIA</abbr> Property ID enumeration value corresponding to that property to get the current value, e.g. <code>IUIAutomationElement::GetCurrentPropertyValue(UIA_NamePropertyId)</code> for the <code>Name</code> property.</li>
+		<li><code>GetCachedPropertyValue</code> and passing the <abbr title="User Interface Automation">UIA</abbr> Property ID enumeration value corresponding to that property to get the cached value, e.g. <code>IUIAutomationElement::GetCachedPropertyValue(UIA_NamePropertyId)</code> for the <code>Name</code> property.</li>
+      	</ul>
+	<p>Properties for specific <abbr title="User Interface Automation">UIA</abbr> control patterns are queried the same way using relevant control pattern interfaces. Taking Toggle Pattern as an example, to query the ToggleState property clients can use IUIAutomationTogglePattern::CurrentToggleState or IUIAutomationTogglePattern::GetCurrentPropertyValue(UIA_ToggleToggleStatePropertyId) to get the current value.</p>
+      	<p>The property mappings in this specification provide the <code>{PropertyName}</code> and do not specify all specific ways to access the property value. Automation clients can access current or cached values using conventions described above, depending on specific needs and coding style conventions.</p>
+      </section>
+      <section id="accessible-names-and-descriptions">
+        <h4 id="x1-2-3-accessible-names-and-descriptions"><bdi class="secno">1.2.3 </bdi>Accessible Names and Descriptions<a class="self-link" href="#accessible-names-and-descriptions" aria-label="Permalink for Section 1.2.3"></a></h4>
+        <p>Each platform accessibility <abbr title="Application Programming Interface">API</abbr> includes a way to assign and retrieve <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-name">accessible name</a> and <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-description">accessible description</a> properties for each <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-object">accessible object</a> created in the <a class="termref informative internalDFN" href="#dfn-accessibility-tree" data-link-type="dfn" id="ref-for-dfn-accessibility-tree-1">accessibility tree</a>. How these properties are implemented and what they are called vary depending on the <abbr title="Application Programming Interface">API</abbr>.</p>
+        <p>For instance, in <abbr title="Microsoft Active Accessibility">MSAA</abbr>, all <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-object">accessible objects</a> support the <code>accName</code> property, which stores the object's <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-name">accessible name</a>. Where the object also supports having an <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-description">accessible description</a>, <abbr title="Microsoft Active Accessibility">MSAA</abbr> stores this property in the object's <code>accDescription</code> property.</p>
+        <p>Software using <abbr title="Accessibility Toolkit">ATK</abbr> can read and write to an object's <code>accessible-name</code> and <code>accessible-description</code> properties. In turn, <abbr title="assistive technology">AT</abbr>-SPI can query the values of those properties through its <code>atspi_accessible_get_name</code> and <code>atspi_accessible_get_description</code> functions.</p>
+        <p>Automation elements in the <abbr title="User Interface Automation">UIA</abbr> accessibility tree have a <code>Name</code> property. Where the object also supports having an <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-description">accessible description</a>, <abbr title="User Interface Automation">UIA</abbr> stores this property in the object's <code>FullDescription</code> property.</p>
+        <p>The approach to <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-name">accessible names</a> and <a class="termref informative" data-lt="accessible description" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-description">accessible descriptions</a> in <abbr title="macOS Accessibility Protocol">AX API</abbr> is somewhat different to the other platform <abbr title="Application Programming Interfaces">APIs</abbr>. <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-name">Accessible names</a> are exposed using the <code>AXTitle</code> property when the name is visually rendered, while the <code>AXDescription</code> property is used when the object's name is not rendered visually. An object's <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-description">accessible description</a>, where provided, should always be exposed in the <code>AXHelp</code> property.</p>
+        <p>For more detail, see the <a class="accname" href="https://w3c.github.io/accname/">Accessible Name and Description Computation</a> specification.</p>
+      </section>
+    </section>
+</section>
+<section id="conformance"><h2 id="x2-conformance"><bdi class="secno">2. </bdi>Conformance<a class="self-link" href="#conformance" aria-label="Permalink for Section 2."></a></h2><p>As well as sections marked as non-normative, all authoring guidelines, diagrams, examples, and notes in this specification are non-normative. Everything else in this specification is normative.</p><p>
+        The key words <em class="rfc2119">MAY</em>, <em class="rfc2119">MUST</em>, <em class="rfc2119">SHOULD</em>, and <em class="rfc2119">SHOULD NOT</em> in this document
+        are to be interpreted as described in
+        <a href="https://datatracker.ietf.org/doc/html/bcp14">BCP 14</a>
+        [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2119" title="Key words for use in RFCs to Indicate Requirement Levels">RFC2119</a></cite>] [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8174" title="Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words">RFC8174</a></cite>]
+        when, and only when, they appear in all capitals, as shown here.
+      </p>
+<section id="rfc-2119-keywords">
+<h3 id="x2-1-rfc-2119-keywords"><bdi class="secno">2.1 </bdi>RFC-2119 Keywords<a class="self-link" href="#rfc-2119-keywords" aria-label="Permalink for Section 2.1"></a></h3>
+<p>RFC-2119 keywords are formatted in uppercase and contained in a <code>strong</code> element with <code>class="rfc2119"</code>. When the keywords shown above are used, but do not share this format, they do not convey formal information in the RFC 2119 sense, and are merely explanatory, i.e., informative. As much as possible, such usages are avoided in this specification.</p>
+</section>
+<section id="normative-and-informative-sections">
+<h3 id="x2-2-normative-and-informative-sections"><bdi class="secno">2.2 </bdi>Normative and Informative Sections<a class="self-link" href="#normative-and-informative-sections" aria-label="Permalink for Section 2.2"></a></h3>
+<p>The indication whether a section is <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-normative">normative</a> or <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-informative">non-normative</a> (informative) applies to the entire section including sub-sections.</p>
+<p>Informative sections provide information useful to understanding the specification. Such sections may contain examples of recommended practice, but it is not required to follow such recommendations in order to conform to this specification.</p>
+</section>
+<section id="features-deprecated-in-wai-aria">
+<h3 id="x2-3-features-deprecated-in-wai-aria"><bdi class="secno">2.3 </bdi>Features Deprecated in <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr><a class="self-link" href="#features-deprecated-in-wai-aria" aria-label="Permalink for Section 2.3"></a></h3>
+<p>The <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> specification <a href="https://w3c.github.io/aria/#deprecated" class="specref">lists some features as deprecated</a>. Although this means authors are encouraged not to use such features, it is expected that the features could still be used in legacy content. Therefore, it is important that user agents continue to map these features to accessibility <abbr title="Application Programming Interfaces">APIs</abbr>, and doing so is part of conformance to this specification. When future versions of the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> specification change such features from deprecated to removed, they will be removed from the mappings as well and user agents will no longer be asked to continue support for those features.</p>
+</section>
+</section>
+<section class="informative" id="glossary">
+  <h2 id="x3-important-terms"><bdi class="secno">3. </bdi>Important Terms<a class="self-link" href="#glossary" aria-label="Permalink for Section 3."></a></h2><p><em>This section is non-normative.</em></p>
+  <div>
+		<p>While some terms are defined in place, the following definitions are used throughout this document. </p>
+		<dl class="termlist">
+			<dt><dfn data-export="" id="dfn-accessibility-subtree" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">Accessibility Subtree</dfn></dt>
+			<dd>
+				<p>An <a data-link-type="dfn" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-object">accessible object</a> in the <a href="#dfn-accessibility-tree" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-accessibility-tree-2">accessibility tree</a> and its descendants in that tree. It does not include objects which have relationships other than parent-child in that tree. For example, it does not include objects linked via <pref>aria-flowto</pref> unless those objects are also descendants in the <a href="#dfn-accessibility-tree" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-accessibility-tree-3">accessibility tree</a>.</p>
+			</dd>
+			<dt><dfn data-export="" id="dfn-accessibility-tree" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">Accessibility Tree</dfn></dt>
+			<dd>
+				<p>Tree of <a class="termref informative" data-lt="accessible object" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-object">accessible objects</a> that represents the structure of the user interface (<abbr title="user interface">UI</abbr>). Each node in the accessibility tree represents an element in the <abbr title="user interface">UI</abbr> as exposed through the <a data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessibility-api">accessibility <abbr title="Application Programming Interface">API</abbr></a>; for example, a push button, a check box, or container.</p>
+			</dd>
+			<dt><dfn data-export="" id="dfn-activation-behavior" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">Activation behavior</dfn></dt>
+			<dd>
+				<p>The action taken when an <a data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-event">event</a>, typically initiated by users through an input device, causes an element to fulfill a defined role. The role may be defined for that element by the host language, or by author-defined variables, or both. The role for any given element may be a generic action, or may be unique to that element. For example, the activation behavior of an <abbr title="Hypertext Markup Language">HTML</abbr> or <abbr title="Scalable Vector Graphics">SVG</abbr> <code>&lt;a&gt;</code> element shall be to cause the user agent to traverse the link specified in the <code>href</code> attribute, with the further optional parameter of specifying the browsing context for the traversal (such as the current window or tab, a named window, or a new window); the activation behavior of an <abbr title="Hypertext Markup Language">HTML</abbr> <code>&lt;input&gt;</code> element with the <code>type</code> attribute value <code>submit</code> shall be to send the values of the form elements to an author-defined <abbr title="Internationalized Resource Identifiers">IRI</abbr> by the author-defined <abbr title="Hypertext Transfer Protocol">HTTP</abbr> method.</p>
+			</dd>
+		</dl>
+	</div>
+</section>
+<section id="mapping">
+	<h2 id="x4-mapping-wai-aria-to-accessibility-apis"><bdi class="secno">4. </bdi>Mapping <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> to Accessibility <abbr title="Application Programming Interfaces">APIs</abbr><a class="self-link" href="#mapping" aria-label="Permalink for Section 4."></a></h2>
+	<section id="mapping_general">
+		<h3 id="x4-1-general-rules-for-exposing-wai-aria-semantics"><bdi class="secno">4.1 </bdi>General rules for exposing <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> semantics<a class="self-link" href="#mapping_general" aria-label="Permalink for Section 4.1"></a></h3>
+		<p>Where supported by the platform <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessibility-api">Accessibility <abbr title="Application Programming Interface">API</abbr></a>, <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-user-agent">user agents</a> expose <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-semantics">semantics</a> through the  standard mechanisms of the desktop accessibility <abbr title="application programming interface">API</abbr>. For example, for  <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-widget">widgets</a>, compare how the widget is exposed in a similar desktop  widget. In general most <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> widget capabilities are exposed through  the <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-role">role</a>, value, Boolean <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-state">states</a>, and relations of the accessibility <abbr title="application programming interface">API</abbr>.</p>
+	    <p>With respect to <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> 1.0 and 1.1, accessibility <abbr title="application programming interfaces">APIs</abbr> operate in one direction only.  User agents publish <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> information (roles, states, and properties) via an accessibility <abbr title="application programming interface">API</abbr>, and an <abbr title="assistive technology">AT</abbr> can acquire that information using the same <abbr title="application programming interface">API</abbr>.  However, the other direction is not supported.  <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> 1.0 and 1.1 do not define mechanisms for assistive technologies to directly modify <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> information.</p>
+		<p>The terms "exposing", "mapping", and "including" refer to the creation of <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-object">accessible object</a> <a class="termref informative" data-lt="node" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-node">nodes</a> within the <a class="termref informative internalDFN" href="#dfn-accessibility-tree" data-link-type="dfn" id="ref-for-dfn-accessibility-tree-4">accessibility tree</a>, and populating these objects with <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessibility-api">Accessibility <abbr title="Application Programming Interface">API</abbr></a> specific <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-state">states</a> and <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-property">properties</a>.</p>
+  </section>
+	<section id="mapping_conflicts">
+		<h3 id="x4-2-conflicts-between-native-markup-semantics-and-wai-aria"><bdi class="secno">4.2 </bdi>Conflicts between native markup semantics and <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr><a class="self-link" href="#mapping_conflicts" aria-label="Permalink for Section 4.2"></a></h3>
+		  <p><abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr>  roles, states, and properties are intended to add <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-semantics">semantic</a> information when native host language <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-element">elements</a> with these semantics are not available, and are generally used on elements that have no native semantics of their own. They can also be used on elements that have similar but not identical semantics to the intended object (for instance, a nested list could be used to represent a tree structure). This method can be  part of a fallback strategy for older browsers that have no <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> implementation, or because native presentation of the repurposed element reduces the amount of style and/or script needed. Except for the cases outlined below, <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-user-agent">user agents</a> <em class="rfc2119">MUST</em> always use the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> semantics to define how it exposes the element to <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessibility-api">accessibility <abbr title="Application Programming Interfaces">APIs</abbr></a>, rather than using the host language semantics.</p>
+		  <p>Host languages can have features that have implicit <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> semantics corresponding to <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-role">roles</a>. When a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role is provided that has a corresponding role in the accessibility <abbr title="Application Programming Interface">API</abbr>, user agents <em class="rfc2119">MUST</em> use the semantic of the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role for processing, not the native semantic, unless the role requires <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> states and properties whose attributes are explicitly forbidden on the native element by the host language.  Values for roles do not conflict in the same way as values for states and properties, and because authors are expected to have a valid reason to provide a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role even on elements that would not normally be repurposed. For example, spin buttons are typically constructed from text fields (<code>&lt;input  type="text"&gt;</code>) in order to get most of the default keyboard support.  But, the native role, "text field", is not correct because it does not properly communicate the additional features of a spin button.  The author adds the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role of <code>spinbutton</code> (<code>&lt;input type="text" role="spinbutton" ...&gt;</code>) so that the control is properly mapped in the accessibility <abbr title="Application Programming Interface">API</abbr>. When a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role is provided that does not have a corresponding role in the accessibility <abbr title="Application Programming Interface">API</abbr>, user agents <em class="rfc2119">MAY</em> expose the native semantic in addition to the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role. If the host language element is overridden by a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role whose semantics or structure is not equivalent to the native host language semantics or to a subclass of those semantics, then treat any required <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-owned-element">owned</a> elements of the native role as having role <a href="#role-map-presentation">presentation</a> or <a href="#role-map-none">none</a>.</p>
+		  <div class="note" role="note" id="issue-container-generatedID"><div role="heading" class="note-title marker" id="h-note" aria-level="4"><span>Note</span></div><p class="">The above text differs slightly from the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> specification. The requirement for user agents to expose the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role instead of the native role was intended to only apply in cases where there is a direct mapping from the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role to a corresponding role in the accessibility <abbr title="Application Programming Interface">API</abbr>. The wording of the requirement is not clear in the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> specification, however, and has been interpreted differently by implementers. The requirement has been clarified here and an additional statement added to indicate that user agents may expose native semantics if there is not a direct mapping to a role in the accessibility <abbr title="Application Programming Interface">API</abbr>. Because there are differing implementations, authors will be advised against adding such <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> roles to native elements that have their own semantics in the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Authoring Practices Guide.</p></div>
+      <p>When <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> states and properties correspond to host language features that have the same implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantic, it can be problematic if the values become out of sync. For example, the <abbr title="Hypertext Markup Language">HTML</abbr> <code>checked</code> attribute and the <code>aria-checked</code> attribute could have conflicting values. Therefore to prevent providing conflicting states and properties to assistive technologies, host languages will explicitly declare where the use of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> attributes on a host language element conflict with native attributes for that element. When a host language declares a <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-attribute">attribute</a> to be in direct semantic conflict with a native attribute for a given element, user agents <em class="rfc2119">MUST</em> ignore the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> attribute and instead use the host language attribute with the same implicit semantic. </p>
+      <p>Host languages might also document features that cannot be overridden with <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> (these are called "strong native semantics"). These can be features that have implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics as well as features where the processing would be uncertain if the semantics were changed with <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>. While conformance checkers might signal an error or warning when a <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role is used on elements with strong native semantics, user agents <em class="rfc2119">MUST</em> still use the value of the semantic of the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role when exposing the element to accessibility <abbr title="Application Programming Interfaces">APIs</abbr>.</p>
+  </section>
+	<section id="mapping_nodirect">
+		<h3 id="x4-3-exposing-attributes-that-do-not-directly-map-to-accessibility-api-properties"><bdi class="secno">4.3 </bdi>Exposing attributes that do not directly map to accessibility <abbr title="application programming interface">API</abbr> properties<a class="self-link" href="#mapping_nodirect" aria-label="Permalink for Section 4.3"></a></h3>
+		  <p>Platform <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessibility-api">accessibility <abbr title="Application Programming Interfaces">APIs</abbr></a> might have features that are not in <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr>. Likewise, <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> exposes capabilities that are not supported by accessibility <abbr title="Application Programming Interfaces">APIs</abbr> at the time of publication. There typically is not a one to one relationship between all <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-attribute">attributes</a> and platform accessibility <abbr title="application programming interfaces">APIs</abbr>. When <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-role">roles</a>, <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-state">states</a> and <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-property">properties</a> do not directly map to an  accessibility <abbr title="application programming interface">API</abbr>, and there is a mechanism in the <abbr title="application programming interface">API</abbr> to expose the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role, states, and properties and their values, <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-user-agent">user agents</a> <em class="rfc2119">MUST</em> expose the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr>  data using that mechanism as follows: </p>
+      <ul>
+        <li>In IAccessible2 and <abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>, use object attributes to expose <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-semantics">semantics</a> that are not directly supported in the <abbr title="application programming interfaces">APIs</abbr>. Object attributes are name-value pairs that are loosely specified, and very flexible for exposing things where there is no specific interface in an accessibility <abbr title="application programming interface">API</abbr>. For example, at this time, the <a class="property-reference" href="https://w3c.github.io/aria/#aria-live"><code>aria-live</code></a> attribute can be exposed via an object attribute because accessibility <abbr title="application programming interfaces">APIs</abbr> have no such property available. Specific rules for exposing object attribute name-value pairs are described throughout this document, and rules for the general cases  are in <a href="#mapping_state-property">State and Property Mapping</a>.</li>
+        <li>In Microsoft <abbr title="User Interface Automation">UIA</abbr>, use the <code>AriaRole</code> and <code>AriaProperties</code> properties to expose semantics that are not directly supported in the control type.</li>
+      </ul>
+      <div class="note" role="note" id="issue-container-generatedID-0"><div role="heading" class="note-title marker" id="h-note-0" aria-level="4"><span>Note</span></div><p class=""><abbr title="Microsoft Active Accessibility">MSAA</abbr> does not provide a mechanism for exposing attributes that do not map directly to the <abbr title="application programming interface">API</abbr> and among implementers, there is no agreement on how to do it.</p></div>
+      <p>User agents <em class="rfc2119">MUST</em> also expose the entire role string through this mechanism and <em class="rfc2119">MAY</em> also expose <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> attributes and values through this mechanism even when there is a direct mapping to an accessibility <abbr title="application programming interface">API</abbr>.</p>
+		  <p>Browser implementers are advised to publicly document their <abbr title="application programming interface">API</abbr> methods for exposing any relevant information, so that <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-assistive-technology">assistive technology</a> developers can use the <abbr title="application programming interface">API</abbr> to support user features.</p>
+	</section>
+	<section id="mapping_role">
+		<h3 id="x4-4-role-mapping"><bdi class="secno">4.4 </bdi>Role mapping<a class="self-link" href="#mapping_role" aria-label="Permalink for Section 4.4"></a></h3>
+		<p>Platform <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessibility-api">accessibility <abbr title="Application Programming Interfaces">APIs</abbr></a> traditionally have had a finite set of predefined <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-role">roles</a> that are expected by <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-assistive-technology">assistive technologies</a> on that platform and only one or two roles may be exposed. In  contrast, <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> allows multiple roles to be specified as an ordered set of space-separated valid role tokens. The additional roles are fallback roles similar to the concept of specifying multiple fonts in case the first choice font type is not supported.</p>
+		<section id="roleMappingGeneralRules">
+		  <h4 id="x4-4-1-general-rules"><bdi class="secno">4.4.1 </bdi>General rules<a class="self-link" href="#roleMappingGeneralRules" aria-label="Permalink for Section 4.4.1"></a></h4>
+		  <p id="exposeRoleString">User agents <em class="rfc2119">MUST</em> expose the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role string if the <abbr title="application programming interface">API</abbr> supports a mechanism to do so. This allows assistive technologies to do their own  additional processing of roles. </p>
+		  <ul>
+			<li><abbr title="Microsoft Active Accessibility">MSAA</abbr>: <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/dd373608(v=vs.85).aspx" title="Object Roles (Windows)">not supported</a>. User agents <em class="rfc2119">SHOULD NOT</em> expose a custom role in <abbr title="Microsoft Active Accessibility">MSAA</abbr>'s <code>accRole</code> property.</li>
+			<li>IAccessible2: expose as an object attribute pair (<code>xml-roles:"string"</code>)</li>
+			<li><abbr title="User Interface Automation">UIA</abbr>: expose as <code>AriaRole</code> property. The <code>AriaRole property</code> can also support secondary roles using a space as a separator.</li>
+			<li><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>: expose as an object attribute pair (<code>xml-roles:"string"</code>)</li>
+		  </ul>
+    </section>
+    <section id="mapping_role_table">
+		<h4 id="x4-4-2-role-mapping-table"><bdi class="secno">4.4.2 </bdi>Role Mapping Table<a class="self-link" href="#mapping_role_table" aria-label="Permalink for Section 4.4.2"></a></h4>
+      <div class="note" role="note" id="issue-container-generatedID-1"><div role="heading" class="note-title marker" id="h-note-1" aria-level="5"><span>Note</span></div><p class="">Translators: For label text associated with the following table and its toggle buttons, see the <code>mappingTableLabels</code> object in the <code>&lt;head&gt;</code> section of this document.</p></div>
+      <div class="table-container" style="display: none;">
+      <table class="map-table elements" id="role-mapping-table">
+      <caption>Table describing mapping of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> roles to accessibility <abbr title="application programming interfaces">APIs</abbr>.</caption>
+			<thead>
+				<tr>
+					<th><abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Role</th>
+					<th><abbr title="Microsoft Active Accessibility">MSAA</abbr> + IAccessible2</th>
+					<th><abbr title="User Interface Automation">UIA</abbr></th>
+					<th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+					<th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#alert"><code>alert</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_ALERT</code></span><br>
+						<span class="event">Event: The user agent <em class="rfc2119">SHOULD</em> fire <code>EVENT_SYSTEM_ALERT</code>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Group</code></span><br>
+						<span class="property">Localized Control Type: <code>alert</code></span><br>
+						<span class="property">LiveSetting: <code>Assertive (2)</code></span><br>
+						<span class="event">Event: The user agent <em class="rfc2119">SHOULD</em> fire a system alert <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-event">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_NOTIFICATION</code></span><br>
+						<span class="event">Event: The user agent <em class="rfc2119">SHOULD</em> fire a system alert <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-event">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXApplicationAlert</code></span><br>
+						<span class="event">Event: The user agent <em class="rfc2119">SHOULD</em> fire a system alert <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-event">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#alertdialog"><code>alertdialog</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_DIALOG</code></span><br>
+						<span class="event">Event: The user agent <em class="rfc2119">SHOULD</em> fire <code>EVENT_SYSTEM_ALERT</code>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Pane</code></span><br>
+						<span class="event">Event: The user agent <em class="rfc2119">SHOULD</em> fire a system alert <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-event">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_ALERT</code></span><br>
+						<span class="property">Interface: <code>Window</code></span><br>
+						<span class="event">Event: The user agent <em class="rfc2119">SHOULD</em> fire a system alert <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-event">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXApplicationAlertDialog</code></span><br>
+						<span class="event">Event: The user agent <em class="rfc2119">SHOULD</em> fire a system alert <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-event">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#application"><code>application</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_APPLICATION</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Pane</code></span><br>
+						<span class="property">Localized Control Type: <code>application</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_EMBEDDED</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXWebApplication</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#article"><code>article</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_DOCUMENT</code></span><br>
+						<span class="property">State: <code>STATE_SYSTEM_READONLY</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:article</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Group</code></span><br>
+						<span class="property">Localized Control Type: <code>article</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_ARTICLE</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:article</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXDocumentArticle</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#banner"><code>banner</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:banner</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Group</code></span><br>
+						<span class="property">Localized Control Type: <code>banner</code></span><br>
+						<span class="property">Landmark Type: <code>Custom</code></span><br>
+						<span class="property">Localized Landmark Type: <code>banner</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_LANDMARK</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:banner</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXLandmarkBanner</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#blockquote"><code>blockquote</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br>
+						<span class="property">Role: <code>IA2_ROLE_SECTION</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Group</code></span><br>
+						<span class="property">Localized Control Type: <code>blockquote</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_BLOCK_QUOTE</code></span><br>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#button"><code>button</code></a> with default values for <a class="property-reference" href="https://w3c.github.io/aria/#aria-pressed"><code>aria-pressed</code></a> and <a class="property-reference" href="https://w3c.github.io/aria/#aria-haspopup"><code>aria-haspopup</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_PUSHBUTTON</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Button</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_PUSH_BUTTON</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXButton</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#button"><code>button</code></a> with non-<code>false</code> value for <code>aria-haspopup</code></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_BUTTONMENU</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Button</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_PUSH_BUTTON</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXPopUpButton</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#button"><code>button</code></a> with defined value for <a class="property-reference" href="https://w3c.github.io/aria/#aria-pressed"><code>aria-pressed</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_PUSHBUTTON</code></span><br>
+						<span class="property">Role: <code>IA2_ROLE_TOGGLE_BUTTON</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Button</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_TOGGLE_BUTTON</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXCheckBox</code></span><br>
+						<span class="property">AXSubrole: <code>AXToggle</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#caption"><code>caption</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_TEXT</code></span><br>
+						<span class="property">Role: <code>IA2_ROLE_CAPTION</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Text</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_CAPTION</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#cell"><code>cell</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_CELL</code></span><br>
+						<span class="property">Interface: <code>IAccessibleTableCell</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>DataItem</code></span><br>
+						<span class="property">Localized Control Type: <code>item</code></span><br>
+						<span class="property">Control Pattern: <code>GridItem</code></span><br>
+						<span class="property">Control Pattern: <code>TableItem</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_TABLE_CELL</code></span><br>
+						<span class="property">Interface: <code>TableCell</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXCell</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#checkbox"><code>checkbox</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_CHECKBUTTON</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Checkbox</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_CHECK_BOX</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXCheckBox</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#code"><code>code</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:code</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Text</code></span><br>
+						<span class="property">Localized Control Type: <code>code</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_STATIC</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:code</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXCodeStyleGroup</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#columnheader"><code>columnheader</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_COLUMNHEADER</code></span><br>
+						<span class="property">Interface: <code>IAccessibleTableCell</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>DataItem</code></span><br>
+						<span class="property">Localized Control Type: <code>column header</code></span><br>
+						<span class="property">Control Pattern: <code>GridItem</code></span><br>
+						<span class="property">Control Pattern: <code>TableItem</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_COLUMN_HEADER</code></span><br>
+						<span class="property">Interface: <code>TableCell</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXCell</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#combobox"><code>combobox</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_COMBOBOX</code></span><br>
+						<span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span><br>
+						<span class="property">State: <code>STATE_SYSTEM_COLLAPSED</code> if <a class="state-reference" href="https://w3c.github.io/aria/#aria-expanded"><code>aria-expanded</code></a> is not <code>"true"</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Combobox</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_COMBO_BOX</code></span><br>
+						<span class="property">State: <code>STATE_EXPANDABLE</code></span><br>
+						<span class="property">State: <code>STATE_HAS_POPUP</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXComboBox</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#comment"><code>comment</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>IA2_ROLE_COMMENT</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:comment</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Group</code></span><br>
+						<span class="property">Localized Control Type: <code>comment</code></span><br>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_COMMENT</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:comment</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#complementary"><code>complementary</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:complementary</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Group</code></span><br>
+						<span class="property">Localized Control Type: <code>complementary</code></span><br>
+						<span class="property">Landmark Type: <code>Custom</code></span><br>
+						<span class="property">Localized Landmark Type: <code>complementary</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_LANDMARK</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:complementary</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXLandmarkComplementary</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#contentinfo"><code>contentinfo</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:contentinfo</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Group</code></span><br>
+						<span class="property">Localized Control Type: <code>content information</code></span><br>
+						<span class="property">Landmark Type: <code>Custom</code></span><br>
+						<span class="property">Localized Landmark Type: <code>content information</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_LANDMARK</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:contentinfo</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXLandmarkContentInfo</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#definition"><code>definition</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Object Attribute: <code>xml-roles:definition</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Group</code></span><br>
+						<span class="property">Localized Control Type: <code>definition</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_DESCRIPTION_VALUE</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:definition</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXDefinition</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#deletion"><code>deletion</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>IA2_ROLE_CONTENT_DELETION</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Text</code></span><br>
+						<span class="property">Localized Control Type: <code>del</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_CONTENT_DELETION</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:deletion</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXDeleteStyleGroup</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#dialog"><code>dialog</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_DIALOG</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Pane</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_DIALOG</code></span><br>
+						<span class="property">Interface: <code>Window</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXApplicationDialog</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#directory"><code>directory</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_LIST</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>List</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_LIST</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXList</code></span><br>
+						<span class="property">AXSubrole: <code>AXContentList</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#document"><code>document</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_DOCUMENT</code></span><br>
+						<span class="property">State: <code>STATE_SYSTEM_READONLY</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Document</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_DOCUMENT_FRAME</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXDocument</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#emphasis"><code>emphasis</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:emphasis</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Text</code></span><br>
+						<span class="property">Localized Control Type: <code>emphasis</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_STATIC</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:emphasis</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXEmphasisStyleGroup</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#feed"><code>feed</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:feed</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Group</code></span><br>
+						<span class="property">Localized Control Type: <code>feed</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_PANEL</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:feed</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXApplicationGroup</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#figure"><code>figure</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:figure</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Group</code></span><br>
+						<span class="property">Localized Control Type: <code>figure</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_PANEL</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:figure</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#form"><code>form</code></a> with an accessible name</th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>IA2_ROLE_FORM</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:form</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Group</code></span><br>
+						<span class="property">Localized Control Type: <code>form</code></span><br>
+						<span class="property">Landmark Type: <code>Form</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_LANDMARK</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:form</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#form"><code>form</code></a> without an accessible name</th>
+					<td class="role-msaa-ia2">
+						<span class="property">Do not expose the <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-element">element</a> as a landmark. Use the native host language role of the element instead.</span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Do not expose the <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-element">element</a> as a landmark. Use the native host language role of the element instead.</span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Do not expose the <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-element">element</a> as a landmark. Use the native host language role of the element instead.</span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">Do not expose the <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-element">element</a> as a landmark. Use the native host language role of the element instead.</span>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#generic"><code>generic</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br>
+						<span class="property">Role: <code>IA2_ROLE_SECTION</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Group</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_SECTION</code></span><br>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#grid"><code>grid</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_TABLE</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:grid</code></span><br>
+						<span class="property">Interface: <code>IAccessibleTable2</code></span><br>
+						<span class="method">Method: <code>IAccessible::accSelect()</code></span><br>
+						<span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>DataGrid</code></span><br>
+						<span class="property">Control Pattern: <code>Grid</code></span><br>
+						<span class="property">Control Pattern: <code>Table</code></span><br>
+						<span class="property">Control Pattern: <code>Selection</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_TABLE</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:grid</code></span><br>
+						<span class="property">Interface: <code>Table</code></span><br>
+						<span class="property">Interface: <code>Selection</code></span>
+						<p>Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility <abbr title="Application Programming Interface">API</abbr>, user agents <em class="rfc2119">MUST</em> return <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.</p>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXTable</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+						<span class="property">AXColumnHeaderUIElements: a list of pointers to the columnheader elements</span><br>
+						<span class="property">AXHeader: a pointer to the row or group containing those columnheader elements</span><br>
+						<span class="property">AXRowHeaderUIElements: a list of pointers to the rowheader elements</span>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#gridcell"><code>gridcell</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_CELL</code></span><br>
+						<span class="property">Interface: <code>IAccessibleTableCell</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>DataItem</code></span><br>
+						<span class="property">Localized Control Type: <code>item</code></span><br>
+						<span class="property">Control Pattern: <code>SelectionItem</code></span><br>
+						<span class="property">Control Pattern: <code>GridItem</code></span><br>
+						<span class="property">Control Pattern: <code>TableItem</code></span><br>
+						<span class="property">SelectionItem.SelectionContainer: the containing <code>grid</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_TABLE_CELL</code></span><br>
+						<span class="property">Interface: <code>TableCell</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXCell</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#group"><code>group</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Group</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_PANEL</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXApplicationGroup</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#heading"><code>heading</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>IA2_ROLE_HEADING</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:heading</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Text</code></span><br>
+						<span class="property">Localized Control Type: <code>heading</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_HEADING</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXHeading</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#img"><code>img</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_GRAPHIC</code></span><br>
+						<span class="property">Interface: <code>IAccessibleImage</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Image</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_IMAGE</code></span><br>
+						<span class="property">Interface: <code>Image</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXImage</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#insertion"><code>insertion</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>IA2_ROLE_CONTENT_INSERTION</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Text</code></span><br>
+						<span class="property">Localized Control Type: <code>ins</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_CONTENT_INSERTION</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:insertion</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXInsertStyleGroup</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#label"><code>label</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_STATICTEXT</code></span><br>
+						<span class="property">Role: <code>IA2_ROLE_LABEL</code></span><br>
+						<span class="seealso">See also: <a href="#ariaLabelledBy">aria-labelledby</a> regarding exposure of the labeled widget.</span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Text</code></span><br>
+						<span class="seealso">See also: <a href="#ariaLabelledBy">aria-labelledby</a> regarding exposure of the labeled widget.</span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_LABEL</code></span><br>
+						<span class="seealso">See also: <a href="#ariaLabelledBy">aria-labelledby</a> regarding exposure of the labeled widget.</span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+						<span class="seealso">See also: <a href="#ariaLabelledBy">aria-labelledby</a> regarding exposure of the labeled widget.</span>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#legend"><code>legend</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_STATICTEXT</code></span><br>
+						<span class="property">Role: <code>IA2_ROLE_LABEL</code></span><br>
+						<span class="seealso">See also: <a href="#ariaLabelledBy">aria-labelledby</a> regarding exposure of the labeled group.</span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Text</code></span><br>
+						<span class="seealso">See also: <a href="#ariaLabelledBy">aria-labelledby</a> regarding exposure of the labeled group.</span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_LABEL</code></span><br>
+						<span class="seealso">See also: <a href="#ariaLabelledBy">aria-labelledby</a> regarding exposure of the labeled group.</span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+						<span class="seealso">See also: <a href="#ariaLabelledBy">aria-labelledby</a> regarding exposure of the labeled group.</span>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#link"><code>link</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_LINK</code></span><br>
+						<span class="property">State: <code>STATE_SYSTEM_LINKED</code></span><br>
+						<span class="property">State: <code>STATE_SYSTEM_LINKED</code></span> on its descendants<br>
+						<span class="property">Interface: <code>IAccessibleHypertext</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>HyperLink</code></span><br>
+						<span class="property">Control Pattern: <code>Value</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_LINK</code></span><br>
+						<span class="property">Interface: <code>HyperlinkImpl</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXLink</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#list"><code>list</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_LIST</code></span><br>
+						<span class="property">State: <code>STATE_SYSTEM_READONLY</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>List</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_LIST</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXList</code></span><br>
+						<span class="property">AXSubrole: <code>AXContentList</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#listbox"><code>listbox</code></a> not owned by or child of <code>combobox</code></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_LIST</code></span><br>
+						<span class="method">Method: <code>IAccessible::accSelect()</code></span><br>
+						<span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>List</code></span><br>
+						<span class="property">Control Pattern: <code>Selection</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_LIST_BOX</code></span><br>
+						<span class="property">Interface: <code>Selection</code></span>
+						<p>Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility <abbr title="Application Programming Interface">API</abbr>, user agents <em class="rfc2119">MUST</em> return <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.</p>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXList</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#listbox"><code>listbox</code></a> owned by or child of <code>combobox</code></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_LIST</code></span><br>
+						<span class="method">Method: <code>IAccessible::accSelect()</code></span><br>
+						<span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>List</code></span><br>
+						<span class="property">Control Pattern: <code>Selection</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_MENU</code></span><br>
+						<span class="property">Interface: <code>Selection</code></span>
+						<p>Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility <abbr title="Application Programming Interface">API</abbr>, user agents <em class="rfc2119">MUST</em> return <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.</p>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXList</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#listitem"><code>listitem</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_LISTITEM</code></span><br>
+						<span class="property">State: <code>STATE_SYSTEM_READONLY</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>ListItem</code></span><br>
+						<span class="property">Control Pattern: <code>SelectionItem</code></span><br>
+						<span class="property">SelectionItem.SelectionContainer: the containing <code>list</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_LIST_ITEM</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#log"><code>log</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Object Attribute: <code>xml-roles:log</code></span><br>
+						<span class="property">Object Attribute: <code>container-live:polite</code></span><br>
+						<span class="property">Object Attribute: <code>live:polite</code></span><br>
+						<span class="property">Object Attribute: <code>container-live-role:log</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Group</code></span><br>
+						<span class="property">Localized Control Type: <code>log</code></span><br>
+						<span class="property">LiveSetting: <code>Polite (1)</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_LOG</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:log</code></span><br>
+						<span class="property">Object Attribute: <code>container-live:polite</code></span><br>
+						<span class="property">Object Attribute: <code>live:polite</code></span><br>
+						<span class="property">Object Attribute: <code>container-live-role:log</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXApplicationLog</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#main"><code>main</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:main</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Group</code></span><br>
+						<span class="property">Localized Control Type: <code>main</code></span><br>
+						<span class="property">Landmark Type: <code>Main</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_LANDMARK</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:main</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXLandmarkMain</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#mark"><code>mark</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br>
+						<span class="property">Role: <code>IA2_ROLE_MARK</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:mark</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Group</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_MARK</code></span><br>
+            <span class="property">Object Attribute: <code>xml-roles:mark</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#marquee"><code>marquee</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_ANIMATION</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:marquee</code></span><br>
+						<span class="property">Object Attribute: <code>container-live:off</code></span><br>
+						<span class="property">Object Attribute: <code>live:off</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Group</code></span><br>
+						<span class="property">Localized Control Type: <code>marquee</code></span><br>
+						<span class="property">LiveSetting: <code>Off (0)</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_MARQUEE</code></span><br>
+						<span class="property">Object Attribute: <code>container-live:off</code></span><br>
+						<span class="property">Object Attribute: <code>live:off</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXApplicationMarquee</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#math"><code>math</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_EQUATION</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Group</code></span><br>
+						<span class="property">Localized Control Type: <code>math</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_MATH</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXDocumentMath</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#menu"><code>menu</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_MENUPOPUP</code></span><br>
+						<span class="method">Method: <code>IAccessible::accSelect()</code></span><br>
+						<span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Menu</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_MENU</code></span><br>
+						<span class="property">Interface: <code>Selection</code></span>
+						<p>Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility <abbr title="Application Programming Interface">API</abbr>, user agents <em class="rfc2119">MUST</em> return <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.</p>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXMenu</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#menubar"><code>menubar</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_MENUBAR</code></span><br>
+						<span class="method">Method: <code>IAccessible::accSelect()</code></span><br>
+						<span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>MenuBar</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_MENU_BAR</code></span><br>
+						<span class="property">Interface: <code>Selection</code></span>
+						<p>Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility <abbr title="Application Programming Interface">API</abbr>, user agents <em class="rfc2119">MUST</em> return <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.</p>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXMenuBar</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#menuitem"><code>menuitem</code></a> not owned by or child of <code>group</code></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_MENUITEM</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>MenuItem</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_MENU_ITEM</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXMenuItem</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#menuitem"><code>menuitem</code></a> owned by or child of <code>group</code></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_MENUITEM</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>MenuItem</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_MENU_ITEM</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXMenuButton</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#menuitemcheckbox"><code>menuitemcheckbox</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_CHECKBUTTON</code> or <code>ROLE_SYSTEM_MENUITEM</code></span><br>
+						<span class="property">Role: <code>IA2_ROLE_CHECK_MENU_ITEM</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>MenuItem</code></span><br>
+						<span class="property">Control Pattern: <code>Toggle</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_CHECK_MENU_ITEM</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXMenuItem</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#menuitemradio"><code>menuitemradio</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_RADIOBUTTON</code> or <code>ROLE_SYSTEM_MENUITEM</code></span><br>
+						<span class="property">Role: <code>IA2_ROLE_RADIO_MENU_ITEM</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>MenuItem</code></span><br>
+						<span class="property">Control Pattern: <code>Toggle</code></span><br>
+						<span class="property">Control Pattern: <code>SelectionItem</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_RADIO_MENU_ITEM</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXMenuItem</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#meter"><code>meter</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>IA2_ROLE_LEVEL_BAR</code></span><br>
+						<span class="property">Interface: <code>IAcesssibleValue</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>ProgressBar</code></span><br>
+						<span class="property">Localized Control Type: <code>meter</code></span><br>
+						<span class="property">Control Pattern: <code>RangeValue</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_LEVEL_BAR</code></span><br>
+						<span class="property">Interface: <code>Value</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXLevelIndicator</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#navigation"><code>navigation</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:navigation</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Group</code></span><br>
+						<span class="property">Localized Control Type: <code>navigation</code></span><br>
+						<span class="property">Landmark Type: <code>Navigation</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_LANDMARK</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:navigation</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXLandmarkNavigation</code></span><br>
+					</td>
+				</tr>
+				<tr>
+				<th><a class="role-reference" href="https://w3c.github.io/aria/#none"><code>none</code></a></th>
+					<td class="role-msaa-ia2">
+						<p>For objects that have required owned descendants (e.g., a grid owns gridcells, a list owns listitems), and the descendant is in the <a class="termref informative internalDFN" href="#dfn-accessibility-tree" data-link-type="dfn" id="ref-for-dfn-accessibility-tree-5">accessibility tree</a>, expose it as <code>IA2_ROLE_TEXT_FRAME</code>.  <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-user-agent">User agents</a> <em class="rfc2119">SHOULD</em> prune empty descendants from the <a class="termref informative internalDFN" href="#dfn-accessibility-tree" data-link-type="dfn" id="ref-for-dfn-accessibility-tree-6">accessibility tree</a>.</p>
+					</td>
+					<td class="role-uia">
+						<p>For objects that have required owned descendants (e.g., a grid owns gridcells, a list owns listitems), and the descendant is in the <a class="termref informative internalDFN" href="#dfn-accessibility-tree" data-link-type="dfn" id="ref-for-dfn-accessibility-tree-7">accessibility tree</a>, expose it using the <code>text</code> pattern.  <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-user-agent">User agents</a> <em class="rfc2119">SHOULD</em> prune empty descendants from the <a class="termref informative internalDFN" href="#dfn-accessibility-tree" data-link-type="dfn" id="ref-for-dfn-accessibility-tree-8">accessibility tree</a>.</p>
+					</td>
+					<td class="role-atk">
+						<p>For objects that have required owned descendants (e.g., a grid owns gridcells, a list owns listitems), and the descendant is in the <a class="termref informative internalDFN" href="#dfn-accessibility-tree" data-link-type="dfn" id="ref-for-dfn-accessibility-tree-9">accessibility tree</a>, expose it as <code>ROLE_SECTION</code>.  <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-user-agent">User agents</a> <em class="rfc2119">SHOULD</em> prune empty descendants from the <a class="termref informative internalDFN" href="#dfn-accessibility-tree" data-link-type="dfn" id="ref-for-dfn-accessibility-tree-10">accessibility tree</a>.</p>
+					</td>
+					<td class="role-axapi">
+						<p>For objects that have required owned descendants (e.g., a grid owns gridcells, a list owns listitems), and the descendant is in the <a class="termref informative internalDFN" href="#dfn-accessibility-tree" data-link-type="dfn" id="ref-for-dfn-accessibility-tree-11">accessibility tree</a>, expose it as <code>AXGroup</code>.  <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-user-agent">User agents</a> <em class="rfc2119">SHOULD</em> prune empty descendants from the <a class="termref informative internalDFN" href="#dfn-accessibility-tree" data-link-type="dfn" id="ref-for-dfn-accessibility-tree-12">accessibility tree</a>.</p>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#note"><code>note</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>IA2_ROLE_NOTE</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Group</code></span><br>
+						<span class="property">Localized Control Type: <code>note</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_COMMENT</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXDocumentNote</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#option"><code>option</code></a> not inside <code>combobox</code></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_LISTITEM</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>ListItem</code></span><br>
+						<span class="property">Control Pattern: <code>Invoke</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_LIST_ITEM</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a><br></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXStaticText</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#option"><code>option</code></a> inside <code>combobox</code></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_LISTITEM</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>ListItem</code></span><br>
+						<span class="property">Control Pattern: <code>Invoke</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_MENU_ITEM</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a><br></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXStaticText</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#paragraph"><code>paragraph</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_TEXT</code></span><br>
+						<span class="property">Role: <code>IA2_ROLE_PARAGRAPH</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Text</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_PARAGRAPH</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#presentation"><code>presentation</code></a></th>
+					<td class="role-msaa-ia2">
+						<p>For objects that have required owned descendants (e.g., a grid owns gridcells, a list owns listitems), and the descendant is in the <a class="termref informative internalDFN" href="#dfn-accessibility-tree" data-link-type="dfn" id="ref-for-dfn-accessibility-tree-13">accessibility tree</a>, expose it as <code>IA2_ROLE_TEXT_FRAME</code>.  <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-user-agent">User agents</a> <em class="rfc2119">SHOULD</em> prune empty descendants from the <a class="termref informative internalDFN" href="#dfn-accessibility-tree" data-link-type="dfn" id="ref-for-dfn-accessibility-tree-14">accessibility tree</a>.</p>
+					</td>
+					<td class="role-uia">
+						<p>For objects that have required owned descendants (e.g., a grid owns gridcells, a list owns listitems), and the descendant is in the <a class="termref informative internalDFN" href="#dfn-accessibility-tree" data-link-type="dfn" id="ref-for-dfn-accessibility-tree-15">accessibility tree</a>, expose it using the <code>text</code> pattern.  <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-user-agent">User agents</a> <em class="rfc2119">SHOULD</em> prune empty descendants from the <a class="termref informative internalDFN" href="#dfn-accessibility-tree" data-link-type="dfn" id="ref-for-dfn-accessibility-tree-16">accessibility tree</a>.</p>
+					</td>
+					<td class="role-atk">
+						<p>For objects that have required owned descendants (e.g., a grid owns gridcells, a list owns listitems), and the descendant is in the <a class="termref informative internalDFN" href="#dfn-accessibility-tree" data-link-type="dfn" id="ref-for-dfn-accessibility-tree-17">accessibility tree</a>, expose it as <code>ROLE_SECTION</code>.  <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-user-agent">User agents</a> <em class="rfc2119">SHOULD</em> prune empty descendants from the <a class="termref informative internalDFN" href="#dfn-accessibility-tree" data-link-type="dfn" id="ref-for-dfn-accessibility-tree-18">accessibility tree</a>.</p>
+					</td>
+					<td class="role-axapi">
+						<p>For objects that have required owned descendants (e.g., a grid owns gridcells, a list owns listitems), and the descendant is in the <a class="termref informative internalDFN" href="#dfn-accessibility-tree" data-link-type="dfn" id="ref-for-dfn-accessibility-tree-19">accessibility tree</a>, expose it as <code>AXGroup</code>.  <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-user-agent">User agents</a> <em class="rfc2119">SHOULD</em> prune empty descendants from the <a class="termref informative internalDFN" href="#dfn-accessibility-tree" data-link-type="dfn" id="ref-for-dfn-accessibility-tree-20">accessibility tree</a>.</p>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#progressbar"><code>progressbar</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_PROGRESSBAR</code></span><br>
+						<span class="property">State: <code>STATE_SYSTEM_READONLY</code></span><br>
+						<span class="property">Interface: <code>IAcesssibleValue</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>ProgressBar</code></span><br>
+						<span class="property">Control Pattern: <code>RangeValue</code> if <code>aria-valuenow</code>, <code>aria-valuemax</code>, or <code>aria-valuemin</code></span> is present
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_PROGRESS_BAR</code></span><br>
+						<span class="property">Interface: <code>Value</code></span>
+						<p>Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the value via the accessibility <abbr title="Application Programming Interface">API</abbr>, user agents <em class="rfc2119">MUST</em> return <code>false</code> for all <code>Value</code> methods that provide a means to modify the value.</p>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXProgressIndicator</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#radio"><code>radio</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_RADIOBUTTON</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>RadioButton</code></span><br>
+						<span class="property">Control Pattern: <code>Toggle</code></span><br>
+						<span class="property">Control Pattern: <code>SelectionItem</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_RADIO_BUTTON</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXRadioButton</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#radiogroup"><code>radiogroup</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>List</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_PANEL</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXRadioGroup</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#region"><code>region</code></a> with an accessible name</th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:region</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Group</code></span><br>
+						<span class="property">Localized Control Type: <code>region</code></span><br>
+						<span class="property">Landmark Type: <code>Custom</code></span><br>
+						<span class="property">Localized Landmark Type: <code>region</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_LANDMARK</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:region</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXLandmarkRegion</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#region"><code>region</code></a> without an accessible name</th>
+					<td class="role-msaa-ia2">
+						<span class="property">Do not expose the <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-element">element</a> as a landmark. Use the native host language role of the element instead.</span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Do not expose the <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-element">element</a> as a landmark. Use the native host language role of the element instead.</span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Do not expose the <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-element">element</a> as a landmark. Use the native host language role of the element instead.</span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">Do not expose the <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-element">element</a> as a landmark. Use the native host language role of the element instead.</span>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#row"><code>row</code></a> not inside <code>treegrid</code></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_ROW</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>DataItem</code></span><br>
+						<span class="property">Localized Control Type: <code>row</code></span><br>
+						<span class="property">Control Pattern: <code>SelectionItem</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_TABLE_ROW</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXRow</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#row"><code>row</code></a> inside <code>treegrid</code></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_OUTLINEITEM</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>DataItem</code></span><br>
+						<span class="property">Localized Control Type: <code>row</code></span><br>
+						<span class="property">Control Pattern: <code>SelectionItem</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_TABLE_ROW</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXRow</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#rowgroup"><code>rowgroup</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Group</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_PANEL</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#rowheader"><code>rowheader</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_ROWHEADER</code></span><br>
+						<span class="property">Interface: <code>IAccessibleTableCell</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>HeaderItem</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_ROW_HEADER</code></span><br>
+						<span class="property">Interface: <code>TableCell</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXCell</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#scrollbar"><code>scrollbar</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_SCROLLBAR</code></span><br>
+						<span class="property">Interface: <code>IAcesssibleValue</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>ScrollBar</code></span><br>
+						<span class="property">Control Pattern: <code>RangeValue</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_SCROLL_BAR</code></span><br>
+						<span class="property">Interface: <code>Value</code></span>
+						<p>Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the value via the accessibility <abbr title="Application Programming Interface">API</abbr>, user agents <em class="rfc2119">MUST</em> return <code>false</code> for all <code>Value</code> methods that provide a means to modify the value.</p>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXScrollBar</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#search"><code>search</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:search</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Group</code></span><br>
+						<span class="property">Localized Control Type: <code>search</code></span><br>
+						<span class="property">Landmark Type: <code>Search</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_LANDMARK</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:search</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXLandmarkSearch</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#searchbox"><code>searchbox</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_TEXT</code></span><br>
+						<span class="property">Object Attribute: <code>text-input-type:search</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Edit</code></span><br>
+						<span class="property">Localized Control Type: <code>search box</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_ENTRY</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:searchbox</code></span><br>
+						<span class="property">Interface: <code>EditableText</code> if <a class="property-reference" href="https://w3c.github.io/aria/#aria-readonly"><code>aria-readonly</code></a> is not <code>"true"</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXTextField</code></span><br>
+						<span class="property">AXSubrole: <code>AXSearchField</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#separator"><code>separator</code></a> (non-focusable)</th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_SEPARATOR</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Separator</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_SEPARATOR</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXSplitter</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#separator"><code>separator</code></a> (focusable)</th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_SEPARATOR</code></span><br>
+						<span class="property">Interface: <code>IAccessibleValue</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Thumb</code></span><br>
+						<span class="property">Control Pattern: <code>RangeValue</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_SEPARATOR</code></span><br>
+						<span class="property">Interface: <code>Value</code></span>
+						<p>Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the value via the accessibility <abbr title="Application Programming Interface">API</abbr>, user agents <em class="rfc2119">MUST</em> return <code>false</code> for all <code>Value</code> methods that provide a means to modify the value.</p>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXSplitter</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#slider"><code>slider</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_SLIDER</code></span><br>
+						<span class="property">Interface: <code>IAcesssibleValue</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Slider</code></span><br>
+						<span class="property">Control Pattern: <code>RangeValue</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_SLIDER</code></span><br>
+						<span class="property">Interface: <code>Value</code></span>
+						<p>Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the value via the accessibility <abbr title="Application Programming Interface">API</abbr>, user agents <em class="rfc2119">MUST</em> return <code>false</code> for all <code>Value</code> methods that provide a means to modify the value.</p>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXSlider</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#spinbutton"><code>spinbutton</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_SPINBUTTON</code></span><br>
+						<span class="property">Interface: <code>IAcesssibleValue</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Spinner</code></span><br>
+						<span class="property">Control Pattern: <code>RangeValue</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_SPIN_BUTTON</code></span><br>
+						<span class="property">Interface: <code>Value</code></span>
+						<p>Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the value via the accessibility <abbr title="Application Programming Interface">API</abbr>, user agents <em class="rfc2119">MUST</em> return <code>false</code> for all <code>Value</code> methods that provide a means to modify the value.</p>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXIncrementor</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#status"><code>status</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_STATUSBAR</code></span><br>
+						<span class="property">Object Attribute: <code>container-live:polite</code></span><br>
+						<span class="property">Object Attribute: <code>live:polite</code></span><br>
+						<span class="property">Object Attribute: <code>container-live-role:status</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Group</code></span><br>
+						<span class="property">Localized Control Type: <code>status</code></span><br>
+						<span class="property">LiveSetting: <code>Polite (1)</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_STATUSBAR</code></span><br>
+						<span class="property">Object Attribute: <code>container-live:polite</code></span><br>
+						<span class="property">Object Attribute: <code>live:polite</code></span><br>
+						<span class="property">Object Attribute: <code>container-live-role:status</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXApplicationStatus</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#strong"><code>strong</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:strong</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Text</code></span><br>
+						<span class="property">Localized Control Type: <code>strong</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_STATIC</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:strong</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXStrongStyleGroup</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#subscript"><code>subscript</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br>
+						<span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span><br>
+						<span class="property">Text Attribute: <code>text-position:sub</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Text</code></span><br>
+						<span class="property">Styles used are exposed by <code>IsSubscript</code> attribute of the <code>TextRange</code> Control Pattern implemented on the accessible object.</span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_SUBSCRIPT</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXSubscriptStyleGroup</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#suggestion"><code>suggestion</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>IA2_ROLE_SUGGESTION</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:suggestion</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Group</code></span><br>
+						<span class="property">Localized Control Type: <code>suggestion</code></span><br>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_SUGGESTION</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:suggestion</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#superscript"><code>superscript</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br>
+						<span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span><br>
+						<span class="property">Text Attribute: <code>text-position:super</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Text</code></span><br>
+						<span class="property">Styles used are exposed by <code>IsSuperscript</code> attribute of the <code>TextRange</code> Control Pattern implemented on the accessible object.</span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_SUPERSCRIPT</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXSuperscriptStyleGroup</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#switch"><code>switch</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_CHECKBUTTON</code></span><br>
+						<span class="property">Role: <code>IA2_ROLE_TOGGLE_BUTTON</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:switch</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Button</code></span><br>
+						<span class="property">Localized Control Type: <code>toggleswitch</code></span><br>
+						<span class="property">Control Pattern: <code>Toggle</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_TOGGLE_BUTTON</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:switch</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXCheckBox</code></span><br>
+						<span class="property">AXSubrole: <code>AXSwitch</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#tab"><code>tab</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_PAGETAB</code></span><br>
+						<span class="property">State: <code>STATE_SYSTEM_SELECTED</code> if focus is inside <a class="role-reference" href="https://w3c.github.io/aria/#tabpanel"><code>tabpanel</code></a> associated with <a class="property-reference" href="https://w3c.github.io/aria/#aria-labelledby"><code>aria-labelledby</code></a></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>TabItem</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_PAGE_TAB</code></span><br>
+						<span class="property">State: <code>STATE_SELECTED</code> if focus is inside <a class="role-reference" href="https://w3c.github.io/aria/#tabpanel"><code>tabpanel</code></a> associated with <a class="property-reference" href="https://w3c.github.io/aria/#aria-labelledby"><code>aria-labelledby</code></a></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXRadioButton</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#table"><code>table</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_TABLE</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:table</code></span><br>
+						<span class="property">Interface: <code>IAccessibleTable2</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Table</code></span><br>
+						<span class="property">Control Pattern: <code>Grid</code></span><br>
+						<span class="property">Control Pattern: <code>Table</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_TABLE</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:table</code></span><br>
+						<span class="property">Interface: <code>Table</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXTable</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+						<span class="property">AXColumnHeaderUIElements: a list of pointers to the columnheader elements</span><br>
+						<span class="property">AXHeader: a pointer to the row or group containing those columnheader elements</span><br>
+						<span class="property">AXRowHeaderUIElements: a list of pointers to the rowheader elements</span>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#tablist"><code>tablist</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_PAGETABLIST</code></span><br>
+						<span class="method">Method: <code>IAccessible::accSelect()</code></span><br>
+						<span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Tab</code></span><br>
+						<span class="property">Control Pattern: <code>Selection</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_PAGE_TAB_LIST</code></span><br>
+						<span class="property">Interface: <code>Selection</code></span>
+						<p>Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility <abbr title="Application Programming Interface">API</abbr>, user agents <em class="rfc2119">MUST</em> return <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.</p>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXTabGroup</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#tabpanel"><code>tabpanel</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_PANE</code> or <code>ROLE_SYSTEM_PROPERTYPAGE</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Pane</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_SCROLL_PANE</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXTabPanel</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#term"><code>term</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:term</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Text</code></span><br>
+						<span class="property">Localized Control Type: <code>term</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_DESCRIPTION_TERM</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXTerm</code></span><br>
+					</td>
+					</tr>
+
+				
+
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#textbox"><code>textbox</code></a> when <code>aria-multiline</code> is <code>false</code></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_TEXT</code></span><br>
+						<span class="property">State: <code>IA2_STATE_SINGLE_LINE</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Edit</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_ENTRY</code></span><br>
+						<span class="property">State: <code>STATE_SINGLE_LINE</code></span><br>
+						<span class="property">Interface: <code>EditableText</code> if <a class="property-reference" href="https://w3c.github.io/aria/#aria-readonly"><code>aria-readonly</code></a> is not <code>"true"</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXTextField</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#textbox"><code>textbox</code></a> when <code>aria-multiline</code> is <code>true</code></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_TEXT</code></span><br>
+						<span class="property">State: <code>IA2_STATE_MULTI_LINE</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Edit</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_ENTRY</code></span><br>
+						<span class="property">State: <code>STATE_MULTI_LINE</code></span><br>
+						<span class="property">Interface: <code>EditableText</code> if <a class="property-reference" href="https://w3c.github.io/aria/#aria-readonly"><code>aria-readonly</code></a> is not <code>"true"</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXTextArea</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#time"><code>time</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_STATICTEXT</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:time</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Text</code></span><br>
+						<span class="property">Localized Control Type: <code>time</code></span><br>
+						<span>Note: create a separate <abbr title="User Interface Automation">UIA</abbr> Control of type Text. This is different from most <abbr title="User Interface Automation">UIA</abbr> text mappings, which only create ranges in the page text pattern.</span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_STATIC</code></span><br>
+						<span class="property">Object Attribute: <code>xml-roles:time</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXTimeGroup</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#timer"><code>timer</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Object Attribute: <code>xml-roles:timer</code></span><br>
+						<span class="property">Object Attribute: <code>container-live:off</code></span><br>
+						<span class="property">Object Attribute: <code>live:off</code></span><br>
+						<span class="property">Object Attribute: <code>container-live-role:timer</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Group</code></span><br>
+						<span class="property">Localized Control Type: <code>timer</code></span><br>
+						<span class="property">LiveSetting: <code>Off (0)</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_TIMER</code></span><br>
+						<span class="property">Object Attribute: <code>container-live:off</code></span><br>
+						<span class="property">Object Attribute: <code>live:off</code></span><br>
+						<span class="property">Object Attribute: <code>container-live-role:timer</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXApplicationTimer</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#toolbar"><code>toolbar</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_TOOLBAR</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>ToolBar</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_TOOL_BAR</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXToolbar</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#tooltip"><code>tooltip</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_TOOLTIP</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>ToolTip</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_TOOL_TIP</code></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXGroup</code></span><br>
+						<span class="property">AXSubrole: <code>AXUserInterfaceTooltip</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#tree"><code>tree</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_OUTLINE</code></span><br>
+						<span class="method">Method: <code>IAccessible::accSelect()</code></span><br>
+						<span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>Tree</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_TREE</code></span><br>
+						<span class="property">Interface: <code>Selection</code></span>
+						<p>Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility <abbr title="Application Programming Interface">API</abbr>, user agents <em class="rfc2119">MUST</em> return <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.</p>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXOutline</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#treegrid"><code>treegrid</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_OUTLINE</code></span><br>
+						<span class="property">Interface: <code>IAccessibleTable2</code></span><br>
+						<span class="method">Method: <code>IAccessible::accSelect()</code></span><br>
+						<span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>DataGrid</code></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_TREE_TABLE</code></span><br>
+						<span class="property">Interface: <code>Table</code></span><br>
+						<span class="property">Interface: <code>Selection</code></span>
+						<p>Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility <abbr title="Application Programming Interface">API</abbr>, user agents <em class="rfc2119">MUST</em> return <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.</p>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXTable</code></span><br>
+						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+					</td>
+				</tr>
+				<tr>
+					<th><a class="role-reference" href="https://w3c.github.io/aria/#treeitem"><code>treeitem</code></a></th>
+					<td class="role-msaa-ia2">
+						<span class="property">Role: <code>ROLE_SYSTEM_OUTLINEITEM</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+					<td class="role-uia">
+						<span class="property">Control Type: <code>TreeItem</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+					<td class="role-atk">
+						<span class="property">Role: <code>ROLE_TREE_ITEM</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+					<td class="role-axapi">
+						<span class="property">AXRole: <code>AXRow</code></span><br>
+						<span class="property">AXSubrole: <code>AXOutlineRow</code></span><br>
+						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+		  </div>
+          <div class="note" role="note" id="ftn.note1"><div role="heading" class="note-title marker" id="h-note-2" aria-level="5"><span>Note</span></div><div class=""><p>
+        	<sup>[Note 1]</sup>
+        	User agent should return a user-presentable, localized string value for the AXRoleDescription.</p>
+        </div></div>
+          <div class="note" role="note" id="ftn.note2"><div role="heading" class="note-title marker" id="h-note-3" aria-level="5"><span>Note</span></div><div class="">
+          <p><sup>[Note 2]</sup> This specification does not currently contain guidance for when user agents should fire system alert events. Some guidance may be added to the specification at a later date but it will be a recommendation (<em class="rfc2119">SHOULD</em>), not a requirement (<em class="rfc2119">MUST</em>).</p>
+        </div></div>
+      </section>
+  </section>
+
+	<section id="mapping_state-property">
+		<h3 id="x4-5-state-and-property-mapping"><bdi class="secno">4.5 </bdi>State and Property Mapping<a class="self-link" href="#mapping_state-property" aria-label="Permalink for Section 4.5"></a></h3>
+	  <p>This section describes how to expose <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria-1.2/#dfn-state">states</a> and <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria-1.2/#dfn-object">object</a> <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria-1.2/#dfn-property">properties</a>. </p>
+	  <section id="statePropertyMappingGeneralRules">
+      <h4 id="x4-5-1-general-rules"><bdi class="secno">4.5.1 </bdi>General rules<a class="self-link" href="#statePropertyMappingGeneralRules" aria-label="Permalink for Section 4.5.1"></a></h4>
+      <ol>
+        <li><a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria-1.2/#dfn-user-agent">User agents</a> <em class="rfc2119">MUST</em> compute <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria-1.2/#dfn-managed-state">managed states</a> <code>VISIBLE</code>/<code>INVISIBLE</code>, <code>SHOWING</code>/<code>OFFSCREEN</code>, etc. This typically is done in the same way as for ordinary <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria-1.2/#dfn-element">elements</a> that do not have <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> attributes present. The <code>FOCUSABLE</code>/<code>FOCUSED</code> states may be affected by <a class="property-reference" href="https://w3c.github.io/aria/#aria-activedescendant"><code>aria-activedescendant</code></a>.</li>
+        <li>User agents <em class="rfc2119">MUST</em> continue to expose native semantics in addition to <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> state and property semantics except where an explicit <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> override is allowed by the host language. For example, an <abbr title="Hypertext Markup Language">HTML</abbr> checkbox may have an <a class="property-reference" href="https://w3c.github.io/aria/#aria-labelledby"><code>aria-labelledby</code></a> attribute but the native <abbr title="Hypertext Markup Language">HTML</abbr> semantics must still be exposed. </li>
+        <li>User agents <em class="rfc2119">MUST</em> expose additional states for certain <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria-1.2/#dfn-role">roles</a> as defined in the <a href="#mapping_role_table">Role Mapping Table</a>.</li>
+        <li>User agents <em class="rfc2119">MUST</em> compute states for the relevant <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria-1.2/#dfn-attribute">attributes</a> and map to the <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria-1.2/#dfn-accessibility-api">accessibility <abbr title="Application Programming Interface">API</abbr></a> as specified in the <a href="#mapping_state-property_table">State and Property Mapping Table</a>. To determine the relevant <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> attributes, refer to the <cite><a href="https://w3c.github.io/aria/#role_definitions" class="specref">Definition of Roles</a></cite> [<cite><a class="bibref" data-link-type="biblio" href="#bib-wai-aria-1.2" title="Accessible Rich Internet Applications (WAI-ARIA) 1.2">WAI-ARIA-1.2</a></cite>]]. Where the author has not provided values for required attributes, user agents <em class="rfc2119">SHOULD</em>  process as if the default value was provided. </li>
+        <li>Some <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> properties are not global, and are only supported on  certain roles. If a non-global <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> state or property is used where it is not supported, user agents <em class="rfc2119">SHOULD NOT</em> map the given <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> property to the platform accessibility <abbr title="application programming interface">API</abbr>.  For example, if <code>aria-checked="true"</code> is specified on <code>&lt;div role="grid"&gt;</code>, it should not be exposed in <abbr title="Microsoft Active Accessibility">MSAA</abbr> implementations as <code>STATE_SYSTEM_CHECKED</code>.</li>
+        <li>When an explicit or inherited role of <code>none</code> or <code>presentation</code> is applied to an element, the user agent <em class="rfc2119">MUST</em> implement  the rules for the <a class="role-reference" href="https://w3c.github.io/aria/#none"><code>none</code></a> or the <a class="role-reference" href="https://w3c.github.io/aria/#presentation"><code>presentation</code></a> <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria-1.2/#dfn-role">role</a> defined in <cite><a class="specref" href="https://w3c.github.io/aria/">Accessible Rich Internet Applications (<abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr>) 1.2</a></cite> [<cite><a class="bibref" data-link-type="biblio" href="#bib-wai-aria-1.2" title="Accessible Rich Internet Applications (WAI-ARIA) 1.2">WAI-ARIA-1.2</a></cite>]].</li>
+      </ol>
+    </section>
+  <section id="mapping_state-property_table">
+    <h4 id="x4-5-2-state-and-property-mapping-table"><bdi class="secno">4.5.2 </bdi>State and Property Mapping Table<a class="self-link" href="#mapping_state-property_table" aria-label="Permalink for Section 4.5.2"></a></h4>
+    <section id="not_mapped">
+      <h5 id="x4-5-2-1-not-mapped"><bdi class="secno">4.5.2.1 </bdi>Not Mapped<a class="self-link" href="#not_mapped" aria-label="Permalink for Section 4.5.2.1"></a></h5>
+      <p>There are a number of occurrences in the table where a given state or property is declared "Not mapped".  In some cases, this occurs for the default value of the state/property, and is equivalent to its absence.  User agents might find it quicker to map the value than check to see if it is the default. For computational efficiency, user agents <em class="rfc2119">MAY</em> expose the state or property value if doing so is equivalent to not mapping it.  These cases are marked with an asterisk.  </p>
+      <p>In other cases, it is mandatory that the state/property not be mapped, since exposing it implies a related affordance.  An example is <a class="state-reference" href="https://w3c.github.io/aria/#aria-grabbed"><code>aria-grabbed</code></a>.  Its absence not only indicates that the accessible object is not grabbed, but further defines it as not grab-able.  These cases are marked as "Not mapped" without an asterisk.  </p> 
+    </section>
+    <div class="note" role="note" id="issue-container-generatedID-2"><div role="heading" class="note-title marker" id="h-note-4" aria-level="5"><span>Note</span></div><p class="">Translators: For label text associated with the following table and its toggle buttons, see the <code>mappingTableLabels</code> object in the <code>&lt;head&gt;</code> section of this document.</p></div>
+    <div class="table-container" style="display: none;">
+            <table class="map-table elements" id="state-property-mapping-table">
+              <caption>
+                <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> state and property mapping rule table
+              </caption>
+              <thead>
+                <tr>
+                  <th><abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> State or Property</th>
+                  <th><abbr title="Microsoft Active Accessibility">MSAA</abbr> + IAccessible2 </th>
+                  <th><abbr title="User Interface Automation">UIA</abbr></th>
+                  <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                  <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                </tr>
+              </thead>
+              <tbody>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-activedescendant"><code>aria-activedescendant</code></a></th>
+				<td class="attr-msaa-ia2">
+					See <a href="#focus_state_event_table">Focus Changes</a>.
+				</td>
+				<td class="attr-uia">
+					See <a href="#focus_state_event_table">Focus Changes</a>.
+				</td>
+				<td class="attr-atk">
+					See <a href="#focus_state_event_table">Focus Changes</a>.
+				</td>
+				<td class="attr-axapi">
+					See <a href="#focus_state_event_table">Focus Changes</a>.<br>
+					<span class="property">Property: <code>AXSelectedRows</code>: pointer to active descendant node</span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-atomic"><code>aria-atomic</code></a>=<code>true</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>atomic:true</code></span><br>
+					<span class="property">Object Attribute: <code>container-atomic:true</code></span><br>
+					<span class="property">Object Attribute: <code>container-atomic:true</code> on all descendants</span><br>
+					<span class="relation">Relation: <code>IA2_RELATION_MEMBER_OF</code> pointing to this element (the atomic root)</span><br>
+					<span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>AriaProperties.atomic</code>: <code>true</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>atomic:true</code></span><br>
+					<span class="property">Object Attribute: <code>container-atomic:true</code></span><br>
+					<span class="property">Object Attribute: <code>container-atomic:true</code> on all descendants</span><br>
+					<span class="relation">Relation: <code>RELATION_MEMBER_OF</code> pointing to this element (the atomic root)</span><br>
+					<span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXARIAAtomic</code>: <code>YES</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-atomic"><code>aria-atomic</code></a>=<code>false</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a>, but if mapped:</span><br>
+					<span class="property">Object Attribute: <code>atomic:false</code></span><br>
+					<span class="property">Object Attribute: <code>container-atomic:false</code></span><br>
+					<span class="property">Object Attribute: <code>container-atomic:false</code> on all descendants</span><br>
+					<span class="relation">Relation: <code>IA2_RELATION_MEMBER_OF</code> pointing to this element (the atomic root)</span><br>
+					<span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>AriaProperties.atomic</code>: <code>false</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a>, but if mapped:</span><br>
+					<span class="property">Object Attribute: <code>atomic:false</code></span><br>
+					<span class="property">Object Attribute: <code>container-atomic:false</code></span><br>
+					<span class="property">Object Attribute: <code>container-atomic:false</code> on all descendants</span><br>
+					<span class="relation">Relation: <code>RELATION_MEMBER_OF</code> pointing to this element (the atomic root)</span><br>
+					<span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXARIAAtomic</code>: <code>NO</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-autocomplete"><code>aria-autocomplete</code></a>=<code>inline</code>, <code>list</code>, or <code>both</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>autocomplete:&lt;value&gt;</code></span><br>
+					<span class="property">State: <code>IA2_STATE_SUPPORTS_AUTOCOMPLETION</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>autocomplete:&lt;value&gt;</code></span><br>
+					<span class="property">State: <code>STATE_SUPPORTS_AUTOCOMPLETION</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-autocomplete"><code>aria-autocomplete</code></a>=<code>none</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-busy"><code>aria-busy</code></a>=<code>true</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>STATE_SYSTEM_BUSY</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>AriaProperties.busy</code>: <code>true</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_BUSY</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXElementBusy</code>: <code>YES</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-busy"><code>aria-busy</code></a>=<code>false</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>STATE_SYSTEM_BUSY</code> not exposed</span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>AriaProperties.busy</code>: <code>false</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_BUSY</code> not exposed</span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXElementBusy</code>: <code>NO</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-checked"><code>aria-checked</code></a>=<code>true</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>STATE_SYSTEM_CHECKED</code></span><br>
+					<span class="property">Object Attribute: <code>checkable:true</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>Toggle.ToggleState</code>: <code>On (1)</code></span><br>
+					<span class="property">Property: <code>SelectionItem.IsSelected</code>: <code>True</code> for <code>radio</code> and <code>menuitemradio</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_CHECKABLE</code></span><br>
+					<span class="property">State: <code>STATE_CHECKED</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXValue</code>: <code>1</code></span><br>
+					<span class="property">Property: <code>AXMenuItemMarkChar</code>: <code>✓</code> for <code>menuitemcheckbox</code> and <code>menuitemradio</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-checked"><code>aria-checked</code></a>=<code>false</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>STATE_SYSTEM_CHECKED</code> not exposed</span><br>
+					<span class="property">Object Attribute: <code>checkable:true</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>Toggle.ToggleState</code>: <code>Off (0)</code></span><br>
+					<span class="property">Property: <code>SelectionItem.IsSelected</code>: <code>False</code> for <code>radio</code> and <code>menuitemradio</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_CHECKABLE</code></span><br>
+					<span class="property">State: <code>STATE_CHECKED</code> not exposed</span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXValue</code>: <code>0</code></span><br>
+					<span class="property">Property: <code>AXMenuItemMarkChar</code>: <code>&lt;nil&gt;</code> for <code>menuitemcheckbox</code> and <code>menuitemradio</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-checked"><code>aria-checked</code></a>=<code>mixed</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>STATE_SYSTEM_MIXED</code></span><br>
+					<span class="property">Object Attribute: <code>checkable:true</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>Toggle.ToggleState</code>: <code>Indeterminate (2)</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_INDETERMINATE</code></span><br>
+					<span class="property">State: <code>STATE_CHECKABLE</code></span><br>
+					<span class="property">State: <code>STATE_CHECKED</code> not exposed</span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXValue</code>: <code>2</code></span><br>
+					<span class="property">Property: <code>AXMenuItemMarkChar</code>: <code>&lt;nil&gt;</code> for <code>menuitemcheckbox</code> and <code>menuitemradio</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-checked"><code>aria-checked</code></a> is undefined</th>
+				<td class="attr-msaa-ia2">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-colcount"><code>aria-colcount</code></a></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>colcount:&lt;value&gt;</code></span><br>
+					<span class="method">Method: <code>IAccessible2::groupPosition()</code>: <code>similarItemsInGroup=&lt;value&gt;</code> on cells and headers</span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>Grid.ColumnCount</code>: <code>&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>colcount</code> should contain the author-provided value.</span><br>
+					<span class="method">Method: <code>atk_table_get_n_columns()</code> should return the actual number of columns.</span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXARIAColumnCount</code>: <code>&lt;value&gt;</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-colindex"><code>aria-colindex</code></a></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>colindex:&lt;value&gt;</code></span><br>
+					<span class="method">Method: <code>IAccessible2::groupPosition()</code>: <code>positionInGroup=&lt;value&gt;</code> on cells and headers</span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>GridItem.Column</code>: <code>&lt;value&gt;</code> (zero-based)</span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>colindex</code> should contain the author-provided value.</span><br>
+					<span class="method">Method: <code>atk_table_cell_get_position()</code> should return the actual (zero-based) column index.</span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXARIAColumnIndex</code>: <code>&lt;value&gt;</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-colindextext"><code>aria-colindextext</code></a></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>colindextext:&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>AriaProperties.colindextext</code>: <code>&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>colindextext:&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: TBD</span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-colspan"><code>aria-colspan</code></a></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>colspan:&lt;value&gt;</code></span><br>
+					<span class="method">Method: <code>IAccessibleTableCell::columnExtent()</code>: <code>&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>GridItem.ColumnSpan</code>: <code>&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>colspan</code> should contain the author-provided value.</span><br>
+					<span class="method">Method: <code>atk_table_cell_get_row_column_span()</code> should return the actual column span.</span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXColumnIndexRange.length</code>: <code>&lt;value&gt;</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-controls"><code>aria-controls</code></a></th>
+				<td class="attr-msaa-ia2">
+					<span class="relation">Relation: <code>IA2_RELATION_CONTROLLER_FOR</code> points to accessible nodes matching IDREFs</span><br>
+					<span class="relation">Reverse Relation: <code>IA2_RELATION_CONTROLLED_BY</code> points to element</span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>ControllerFor</code>: pointers to accessible nodes matching IDREFs</span>
+				</td>
+				<td class="attr-atk">
+					<span class="relation">Relation: <code>RELATION_CONTROLLER_FOR</code> points to accessible nodes matching IDREFs</span><br>
+					<span class="relation">Reverse Relation: <code>RELATION_CONTROLLED_BY</code> points to element</span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXLinkedUIElements</code>: pointers to accessible nodes matching IDREFs</span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-current"><code>aria-current</code></a> with non-<code>false</code> allowed value</th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>current:&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>AriaProperties.current</code>: <code>&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>current:&lt;value&gt;</code></span><br>
+					<span class="property">State: <code>STATE_ACTIVE</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXARIACurrent</code>: <code>&lt;value&gt;</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-current"><code>aria-current</code></a> with unrecognized value</th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>current:true</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>AriaProperties.current</code>: <code>true</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>current:true</code></span><br>
+					<span class="property">State: <code>STATE_ACTIVE</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXARIACurrent</code>: <code>true</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-current"><code>aria-current</code></a> is <code>false</code> or undefined</th>
+				<td class="attr-msaa-ia2">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-describedby"><code>aria-describedby</code></a></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Property: <code>accDescription</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="relation">Relation: <code>IA2_RELATION_DESCRIBED_BY</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br>
+					<span class="relation">Reverse Relation: <code>IA2_RELATION_DESCRIPTION_FOR</code> points to element</span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a> and <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>FullDescription</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="property">Property: <code>DescribedBy</code>: points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Property: <code>Description</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="relation">Relation: <code>RELATION_DESCRIBED_BY</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br>
+					<span class="relation">Reverse Relation: <code>RELATION_DESCRIPTION_FOR</code> points to element</span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a> and <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXHelp</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-description"><code>aria-description</code></a></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Property: <code>accDescription</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>FullDescription</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Property: <code>Description</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXHelp</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-details"><code>aria-details</code></a></th>
+				<td class="attr-msaa-ia2">
+					<span class="relation">Relation: <code>IA2_RELATION_DETAILS</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br>
+					<span class="relation">Reverse Relation: <code>IA2_RELATION_DETAILS_FOR</code> points to element</span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>DescribedBy</code>: points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span>
+				</td>
+				<td class="attr-atk">
+					<span class="relation">Relation: <code>RELATION_DETAILS</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br>
+					<span class="relation">Reverse Relation: <code>RELATION_DETAILS_FOR</code> points to element</span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-disabled"><code>aria-disabled</code></a>=<code>true</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>STATE_SYSTEM_UNAVAILABLE</code></span><br>
+					<span class="property">State: <code>STATE_SYSTEM_UNAVAILABLE</code> on all descendants with <code>STATE_SYSTEM_FOCUSABLE</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>IsEnabled</code>: <code>false</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_ENABLED</code> not exposed</span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXEnabled</code>: <code>NO</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-disabled"><code>aria-disabled</code></a>=<code>false</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>STATE_SYSTEM_UNAVAILABLE</code> not exposed</span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>IsEnabled</code>: <code>true</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_ENABLED</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXEnabled</code>: <code>YES</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-dropeffect"><code>aria-dropeffect</code></a>=<code>copy</code>, <code>move</code>, <code>link</code>, <code>execute</code>, or <code>popup</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>dropeffect:&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>AriaProperties.dropeffect</code>: <code>&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>dropeffect:&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-axapi">
+					<code>array AXDropEffects</code>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-dropeffect"><code>aria-dropeffect</code></a>=<code>none</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>dropeffect:none</code> if there are no other valid tokens</span><br>
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a> if not specified by the author</span>
+				</td>
+				<td class="attr-uia">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>dropeffect:none</code> if there are no other valid tokens</span><br>
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a> if not specified by the author</span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-errormessage"><code>aria-errormessage</code></a></th>
+				<td class="attr-msaa-ia2">
+					<span class="relation">Relation: <code>IA2_RELATION_ERROR</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br>
+					<span class="relation">Reverse Relation: <code>IA2_RELATION_ERROR_FOR</code> points to element</span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>ControllerFor</code>: pointer to the target accessible object</span>
+				</td>
+				<td class="attr-atk">
+					<span class="relation">Relation: <code>RELATION_ERROR_MESSAGE</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br>
+					<span class="relation">Reverse Relation: <code>RELATION_ERROR_FOR</code> points to element</span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXValidationError</code>: textual content of the referenced element</span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-expanded"><code>aria-expanded</code></a>=<code>true</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>STATE_SYSTEM_EXPANDED</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>ExpandCollapse.ExpandCollapseState</code>: <code>Expanded</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_EXPANDABLE</code></span><br>
+					<span class="property">State: <code>STATE_EXPANDED</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXExpanded</code>: <code>YES</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-expanded"><code>aria-expanded</code></a>=<code>false</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>STATE_SYSTEM_COLLAPSED</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>ExpandCollapse.ExpandCollapseState</code>: <code>Collapsed</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_EXPANDABLE</code></span><br>
+					<span class="property">State: <code>STATE_EXPANDED</code> not exposed</span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXExpanded</code>: <code>NO</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-expanded"><code>aria-expanded</code></a> is undefined</th>
+				<td class="attr-msaa-ia2">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-flowto"><code>aria-flowto</code></a></th>
+				<td class="attr-msaa-ia2">
+					<span class="relation">Relation: <code>IA2_RELATION_FLOW_TO</code> points to accessible nodes matching IDREFs</span><br>
+					<span class="relation">Reverse Relation: <code>IA2_RELATION_FLOW_FROM</code> points to element</span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>FlowsTo</code>: pointers to accessible nodes matching IDREFs</span>
+				</td>
+				<td class="attr-atk">
+					<span class="relation">Relation: <code>RELATION_FLOWS_TO</code> points to accessible nodes matching IDREFs</span><br>
+					<span class="relation">Reverse Relation: <code>RELATION_FLOWS_FROM</code> points to element</span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXLinkedUIElements</code>: pointers to accessible nodes matching IDREFs</span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-grabbed"><code>aria-grabbed</code></a>=<code>true</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>grabbed:true</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>AriaProperties.grabbed</code>: <code>true</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>grabbed:true</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXGrabbed</code>: <code>YES</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-grabbed"><code>aria-grabbed</code></a>=<code>false</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>grabbed:false</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>AriaProperties.grabbed</code>: <code>false</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>grabbed:false</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXGrabbed</code>: <code>NO</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-grabbed"><code>aria-grabbed</code></a> is undefined</th>
+				<td class="attr-msaa-ia2">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-haspopup"><code>aria-haspopup</code></a>=<code>true</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span><br>
+					<span class="property">Object Attribute: <code>haspopup:true</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Control Pattern: <code>ExpandCollapse</code></span>
+					<span class="seealso">See also: <a class="state-reference" href="https://w3c.github.io/aria/#aria-expanded"><code>aria-expanded</code></a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_HAS_POPUP</code></span><br>
+					<span class="property">Object Attribute: <code>haspopup:true</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>Action</code>: <code>AXShowMenu</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-haspopup"><code>aria-haspopup</code></a>=<code>false</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code> not exposed</span><br>
+					<span class="property">Object Attribute: <code>haspopup:false</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-haspopup"><code>aria-haspopup</code></a>=<code>dialog</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span><br>
+					<span class="property">Object Attribute: <code>haspopup:dialog</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Control Pattern: <code>ExpandCollapse</code></span><br>
+					<span class="seealso">See also: <a class="state-reference" href="https://w3c.github.io/aria/#aria-expanded"><code>aria-expanded</code></a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_HAS_POPUP</code></span><br>
+					<span class="property">Object Attribute: <code>haspopup:dialog</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="action">Action: <code>AXShowMenu</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-haspopup"><code>aria-haspopup</code></a>=<code>listbox</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span><br>
+					<span class="property">Object Attribute: <code>haspopup:listbox</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Control Pattern: <code>ExpandCollapse</code></span><br>
+					<span class="seealso">See also: <a class="state-reference" href="https://w3c.github.io/aria/#aria-expanded"><code>aria-expanded</code></a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_HAS_POPUP</code></span><br>
+					<span class="property">Object Attribute: <code>haspopup:listbox</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="action">Action: <code>AXShowMenu</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-haspopup"><code>aria-haspopup</code></a>=<code>menu</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span><br>
+					<span class="property">Object Attribute: <code>haspopup:menu</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Control Pattern: <code>ExpandCollapse</code></span><br>
+					<span class="seealso">See also: <a class="state-reference" href="https://w3c.github.io/aria/#aria-expanded"><code>aria-expanded</code></a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_HAS_POPUP</code></span><br>
+					<span class="property">Object Attribute: <code>haspopup:menu</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="action">Action: <code>AXShowMenu</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-haspopup"><code>aria-haspopup</code></a>=<code>tree</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span><br>
+					<span class="property">Object Attribute: <code>haspopup:tree</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Control Pattern: <code>ExpandCollapse</code></span><br>
+					<span class="seealso">See also: <a class="state-reference" href="https://w3c.github.io/aria/#aria-expanded"><code>aria-expanded</code></a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_HAS_POPUP</code></span><br>
+					<span class="property">Object Attribute: <code>haspopup:tree</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="action">Action: <code>AXShowMenu</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-hidden"><code>aria-hidden</code></a>=<code>true</code> on unfocused element</th>
+				<td class="attr-msaa-ia2">
+					<span class="property not-in-tree">Element <em class="rfc2119">SHOULD NOT</em> be exposed</span><br>
+					<span class="seealso">See also: <a class="specref" href="https://w3c.github.io/aria/#tree_inclusion">Including Elements in the Accessibility Tree in the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> specification</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property not-in-tree">Element <em class="rfc2119">SHOULD NOT</em> be exposed</span><br>
+					<span class="seealso">See also: <a class="specref" href="https://w3c.github.io/aria/#tree_inclusion">Including Elements in the Accessibility Tree in the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> specification</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property not-in-tree">Element <em class="rfc2119">SHOULD NOT</em> be exposed</span><br>
+					<span class="seealso">See also: <a class="specref" href="https://w3c.github.io/aria/#tree_inclusion">Including Elements in the Accessibility Tree in the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> specification</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property not-in-tree">Element <em class="rfc2119">SHOULD NOT</em> be exposed</span><br>
+					<span class="seealso">See also: <a class="specref" href="https://w3c.github.io/aria/#tree_inclusion">Including Elements in the Accessibility Tree in the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> specification</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-hidden"><code>aria-hidden</code></a>=<code>true</code> when element is focused or fires an accessibility event</th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>hidden:true</code></span><br>
+					<span class="seealso">See also: <a class="specref" href="https://w3c.github.io/aria/#tree_inclusion">Including Elements in the Accessibility Tree in the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> specification</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>AriaProperties.hidden</code>: <code>true</code></span><br>
+					<span class="seealso">See also: <a class="specref" href="https://w3c.github.io/aria/#tree_inclusion">Including Elements in the Accessibility Tree in the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> specification</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>hidden:true</code></span><br>
+					<span class="seealso">See also: <a class="specref" href="https://w3c.github.io/aria/#tree_inclusion">Including Elements in the Accessibility Tree in the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> specification</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span><br>
+					<span class="seealso">See also: <a class="specref" href="https://w3c.github.io/aria/#tree_inclusion">Including Elements in the Accessibility Tree in the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> specification</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-hidden"><code>aria-hidden</code></a>=<code>false</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-invalid"><code>aria-invalid</code></a>=<code>true</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>IA2_STATE_INVALID_ENTRY</code></span><br>
+					<span class="property">Text Attribute: <code>invalid:true</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>IsDataValidForForm</code>: <code>false</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_INVALID_ENTRY</code></span><br>
+					<span class="property">Text Attribute: <code>invalid:true</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXInvalid</code>: <code>true</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-invalid"><code>aria-invalid</code></a>=<code>false</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>IA2_STATE_INVALID_ENTRY</code> not exposed</span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>IsDataValidForForm</code>: <code>true</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_INVALID_ENTRY</code> not exposed</span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXInvalid</code>: <code>false</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-invalid"><code>aria-invalid</code></a>=<code>spelling</code> or <code>grammar</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>IA2_STATE_INVALID_ENTRY</code></span><br>
+					<span class="property">Text Attribute: <code>invalid:&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>IsDataValidForForm</code>: <code>&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_INVALID_ENTRY</code></span><br>
+					<span class="property">Text Attribute: <code>invalid:&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXInvalid</code>: <code>&lt;value&gt;</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-invalid"><code>aria-invalid</code></a> with unrecognized value</th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>IA2_STATE_INVALID_ENTRY</code></span><br>
+					<span class="property">Text Attribute: <code>invalid:true</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>IsDataValidForForm</code>: <code>false</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_INVALID_ENTRY</code></span><br>
+					<span class="property">Text Attribute: <code>invalid:true</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXInvalid</code>: <code>true</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-keyshortcuts"><code>aria-keyshortcuts</code></a></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Property: <code>accKeyboardShortcut</code>: <code>&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>AcceleratorKey</code>: <code>&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>keyshortcuts:&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-label"><code>aria-label</code></a></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Property: <code>accName</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>Name</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Property: <code>Name</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXDescription</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-labelledby"><code>aria-labelledby</code></a></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Property: <code>accName</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="relation">Relation: <code>IA2_RELATION_LABELLED_BY</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br>
+					<span class="relation">Reverse Relation: <code>IA2_RELATION_LABEL_FOR</code> points to element</span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a> and <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>Name</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="property">Property: <code>LabeledBy</code>: points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Property: <code>Name</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="relation">Relation: <code>RELATION_LABELLED_BY</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br>
+					<span class="relation">Reverse Relation: <code>RELATION_LABEL_FOR</code> points to element</span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a> and <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXDescription</code>: <code>&lt;value&gt;</code></span> if the value is not exposed visually<br>
+					<span class="property">Property: <code>AXTitle</code>: <code>&lt;value&gt;</code></span> if the value is exposed visually<br>
+					<span class="property">Property: <code>AXTitleUIElement</code> points to accessible node matching IDREF, if there is a single referenced element that is in the accessibility tree</span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-level"><code>aria-level</code></a> on non-<code>heading</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>level:&lt;value&gt;</code></span><br>
+
+					<span class="method">Method: <code>IAccessible2::groupPosition()</code>: <code>groupLevel=&lt;value&gt;</code> on roles that support <code>aria-posinset</code> and <code>aria-setsize</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_group_position"><code>groupPosition()</code></a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>AriaProperties.level</code>: <code>&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>level:&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXDisclosureLevel</code>: <code>&lt;value&gt;</code> (zero-based), when used on an outline row (like a <a class="role-reference" href="https://w3c.github.io/aria/#treeitem"><code>treeitem</code></a> or <a class="role-reference" href="https://w3c.github.io/aria/#group"><code>group</code></a>)</span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-level"><code>aria-level</code></a> on <code>heading</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>level:&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>AriaProperties.level</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="property">Property: <code>StyleId_Heading</code>: <code>&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>level:&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXValue</code>: <code>&lt;value&gt;</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-live"><code>aria-live</code></a>=<code>assertive</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>live:assertive</code></span><br>
+					<span class="property">Object Attribute: <code>container-live:assertive</code></span><br>
+					<span class="property">Object Attribute: <code>container-live:assertive</code> on all descendants</span><br>
+					<span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code><code>LiveSetting</code></code>: <code>"assertive"</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>live:assertive</code></span><br>
+					<span class="property">Object Attribute: <code>container-live:assertive</code></span><br>
+					<span class="property">Object Attribute: <code>container-live:assertive</code> on all descendants</span><br>
+					<span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXARIALive</code>: <code>"assertive"</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-live"><code>aria-live</code></a>=<code>polite</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>live:polite</code></span><br>
+					<span class="property">Object Attribute: <code>container-live:polite</code></span><br>
+					<span class="property">Object Attribute: <code>container-live:polite</code> on all descendants</span><br>
+					<span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code><code>LiveSetting</code></code>: <code>"polite"</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>live:polite</code></span><br>
+					<span class="property">Object Attribute: <code>container-live:polite</code></span><br>
+					<span class="property">Object Attribute: <code>container-live:polite</code> on all descendants</span><br>
+					<span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXARIALive</code>: <code>"polite"</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-live"><code>aria-live</code></a>=<code>off</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>live:off</code></span><br>
+					<span class="property">Object Attribute: <code>container-live:off</code></span><br>
+					<span class="property">Object Attribute: <code>container-live:off</code> on all descendants</span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code><code>LiveSetting</code></code>: <code>"off"</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>live:off</code></span><br>
+					<span class="property">Object Attribute: <code>container-live:off</code></span><br>
+					<span class="property">Object Attribute: <code>container-live:off</code> on all descendants</span><br>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXARIALive</code>: <code>"off"</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-modal"><code>aria-modal</code></a>=<code>true</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>IA2_STATE_MODAL</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>Window.IsModal</code>: <code>true</code></span><br>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_MODAL</code></span>
+				</td>
+				<td class="attr-axapi">
+					Prune the accessibility tree such that the background content is no longer exposed. No specific property is set on the <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-object">accessible object</a> that corresponds to the <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-element">element</a> with <code>aria-modal="true"</code>. Only the tree whose root is that modal accessible object is exposed.
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-modal"><code>aria-modal</code></a>=<code>false</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>IA2_STATE_MODAL</code> not exposed</span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>Window.IsModal</code>: <code>false</code></span><br>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_MODAL</code> not exposed</span>
+				</td>
+				<td class="attr-axapi">
+					Grow the accessibility tree such that the background content is exposed. No specific property is set on the <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-object">accessible object</a> that corresponds to the <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-element">element</a> with <code>aria-modal="false"</code>.
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-multiline"><code>aria-multiline</code></a>=<code>true</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>IA2_STATE_MULTI_LINE</code></span><br>
+					<span class="property">State: <code>IA2_STATE_SINGLE_LINE</code> not exposed</span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>AriaProperties.multiline</code>: <code>true</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_MULTI_LINE</code></span><br>
+					<span class="property">State: <code>STATE_SINGLE_LINE</code> not exposed</span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span><br>
+					<span class="seealso">See also: <a href="#role-map-textbox"><code>textbox</code></a> in the Role Mapping Table</span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-multiline"><code>aria-multiline</code></a>=<code>false</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>IA2_STATE_SINGLE_LINE</code></span><br>
+					<span class="property">State: <code>IA2_STATE_MULTI_LINE</code> not exposed</span>
+				</td>
+				<td class="attr-uia">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_SINGLE_LINE</code></span><br>
+					<span class="property">State: <code>STATE_MULTI_LINE</code> not exposed</span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span><br>
+					<span class="seealso">See also: <a href="#role-map-textbox"><code>textbox</code></a> in the Role Mapping Table</span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-multiselectable"><code>aria-multiselectable</code></a>=<code>true</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>STATE_SYSTEM_MULTISELECTABLE</code></span><br>
+					<span class="property">State: <code>STATE_SYSTEM_EXTSELECTABLE</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>Selection.CanSelectMultiple</code>: <code>true</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_MULTISELECTABLE</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span><br>
+					<span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-multiselectable"><code>aria-multiselectable</code></a>=<code>false</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>STATE_SYSTEM_MULTISELECTABLE</code> not exposed</span><br>
+					<span class="property">State: <code>STATE_SYSTEM_EXTSELECTABLE</code> not exposed</span><br>
+					<span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
+				</td>
+				<td class="attr-uia">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_MULTISELECTABLE</code> not exposed</span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-orientation"><code>aria-orientation</code></a>=<code>horizontal</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>IA2_STATE_HORIZONTAL</code></span><br>
+					<span class="property">State: <code>IA2_STATE_VERTICAL</code> not exposed</span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>Orientation</code>: <code>horizontal</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_HORIZONTAL</code></span><br>
+					<span class="property">State: <code>STATE_VERTICAL</code> not exposed</span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXOrientation</code>: <code>AXHorizontalOrientation</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-orientation"><code>aria-orientation</code></a>=<code>vertical</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>IA2_STATE_VERTICAL</code></span><br>
+					<span class="property">State: <code>IA2_STATE_HORIZONTAL</code> not exposed</span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>Orientation</code>: <code>vertical</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_VERTICAL</code></span><br>
+					<span class="property">State: <code>STATE_HORIZONTAL</code> not exposed</span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXOrientation</code>: <code>AXVerticalOrientation</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-orientation"><code>aria-orientation</code></a> is undefined</th>
+				<td class="attr-msaa-ia2">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_VERTICAL</code> not exposed</span><br>
+					<span class="property">State: <code>STATE_HORIZONTAL</code> not exposed</span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXOrientation</code>: <code>AXUnknownOrientation</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-owns"><code>aria-owns</code></a></th>
+				<td class="attr-msaa-ia2">
+                                        <p>User agents <em class="rfc2119">MAY</em> expose the elements that are referenced by this property as children of the current element. In which case, if multiple <a class="property-reference" href="https://w3c.github.io/aria/#aria-owns"><code>aria-owns</code></a> relationships are found, use only the first one.	If the accessibility tree is not modified, expose as:</p>
+					<span class="relation">Relation: <code>IA2_RELATION_NODE_PARENT_OF</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br>
+					<span class="relation">Reverse Relation: <code>IA2_RELATION_NODE_CHILD_OF</code> points to element</span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+				</td>
+				<td class="attr-uia">
+                                        Expose the elements that are referenced by this property as children of the current element. If multiple <a class="property-reference" href="https://w3c.github.io/aria/#aria-owns"><code>aria-owns</code></a> relationships are found, use only the first one.
+				</td>
+				<td class="attr-atk">
+                                        <p>User agents <em class="rfc2119">MAY</em> expose the elements that are referenced by this property as children of the current element. In which case, if multiple <a class="property-reference" href="https://w3c.github.io/aria/#aria-owns"><code>aria-owns</code></a> relationships are found, use only the first one.	If the accessibility tree is not modified, expose as:</p>
+					<span class="relation">Relation: <code>RELATION_NODE_PARENT_OF</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br>
+					<span class="relation">Reverse Relation: <code>RELATION_NODE_CHILD_OF</code> points to element</span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXOwns</code>: pointers to accessible nodes matching IDREFs</span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-placeholder"><code>aria-placeholder</code></a></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>placeholder-text:&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>HelpText</code>: <code>&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>placeholder-text:&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXPlaceholderValue</code>: <code>&lt;value&gt;</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-posinset"><code>aria-posinset</code></a></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>posinset:&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>AriaProperties.posinset</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>posinset:&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXARIAPosInSet</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-pressed"><code>aria-pressed</code></a>=<code>true</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>STATE_SYSTEM_PRESSED</code></span><br>
+					<span class="seealso">See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>Toggle.ToggleState</code>: <code>On (1)</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_PRESSED</code></span><br>
+					<span class="seealso">See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXValue</code>: <code>1</code></span><br>
+					<span class="seealso">See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-pressed"><code>aria-pressed</code></a>=<code>mixed</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>STATE_SYSTEM_MIXED</code></span><br>
+					<span class="seealso">See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>Toggle.ToggleState</code>: <code>Indeterminate (2)</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_INDETERMINATE</code></span><br>
+					<span class="seealso">See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXValue</code>: <code>2</code></span><br>
+					<span class="seealso">See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-pressed"><code>aria-pressed</code></a>=<code>false</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>STATE_SYSTEM_PRESSED</code> not exposed</span><br>
+					<span class="seealso">See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>Toggle.ToggleState</code>: <code>Off (3)</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_PRESSED</code> not exposed</span><br>
+					<span class="seealso">See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXValue</code>: <code>0</code></span><br>
+					<span class="seealso">See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-pressed"><code>aria-pressed</code></a> is undefined</th>
+				<td class="attr-msaa-ia2">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-readonly"><code>aria-readonly</code></a>=<code>true</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>STATE_SYSTEM_READONLY</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>Value.IsReadOnly</code>: <code>true</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_READ_ONLY</code></span><br>
+					<span class="property">State: <code>STATE_EDITABLE</code> not exposed on text input roles</span><br>
+					<span class="property">State: <code>STATE_CHECKABLE</code> not exposed on roles supporting <a class="state-reference" href="https://w3c.github.io/aria/#aria-checked"><code>aria-checked</code></a></span><br>
+					<span class="property">State: <code>STATE_CHECKABLE</code> not exposed on <a class="role-reference" href="https://w3c.github.io/aria/#radio">radio</a> descendants when used on a <code>radiogroup</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="method">Method: <code>AXUIElementIsAttributeSettable(AXValue)</code>: <code>NO</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-readonly"><code>aria-readonly</code></a>=<code>false</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>STATE_SYSTEM_READONLY</code> not exposed</span><br>
+					<span class="property">State: <code>IA2_STATE_EDITABLE</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>Value.IsReadOnly</code>: <code>false</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_READ_ONLY</code> not exposed</span>
+				</td>
+				<td class="attr-axapi">
+					<span class="method">Method: <code>AXUIElementIsAttributeSettable(AXValue)</code>: <code>YES</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-readonly"><code>aria-readonly</code></a> is unspecified on <code>gridcell</code></th>
+				<td class="attr-msaa-ia2">
+					The <code>gridcell</code> <em class="rfc2119">MUST</em> inherit any author-provided value for <code>aria-readonly</code> from the containing <code>grid</code> or <code>treegrid</code>. Expose the inherited value on the <code>gridcell</code> as described for <a href="#ariaReadonlyTrue"><code>aria-readonly="true"</code></a> and <a href="#ariaReadonlyFalse"><code>aria-readonly="false"</code></a>.
+				</td>
+				<td class="attr-uia">
+					The <code>gridcell</code> <em class="rfc2119">MUST</em> inherit any author-provided value for <code>aria-readonly</code> from the containing <code>grid</code> or <code>treegrid</code>. Expose the inherited value on the <code>gridcell</code> as described for <a href="#ariaReadonlyTrue"><code>aria-readonly="true"</code></a> and <a href="#ariaReadonlyFalse"><code>aria-readonly="false"</code></a>.
+				</td>
+				<td class="attr-atk">
+					The <code>gridcell</code> <em class="rfc2119">MUST</em> inherit any author-provided value for <code>aria-readonly</code> from the containing <code>grid</code> or <code>treegrid</code>. Expose the inherited value on the <code>gridcell</code> as described for <a href="#ariaReadonlyTrue"><code>aria-readonly="true"</code></a> and <a href="#ariaReadonlyFalse"><code>aria-readonly="false"</code></a>.
+				</td>
+				<td class="attr-axapi">
+					The <code>gridcell</code> <em class="rfc2119">MUST</em> inherit any author-provided value for <code>aria-readonly</code> from the containing <code>grid</code> or <code>treegrid</code>. Expose the inherited value on the <code>gridcell</code> as described for <a href="#ariaReadonlyTrue"><code>aria-readonly="true"</code></a> and <a href="#ariaReadonlyFalse"><code>aria-readonly="false"</code></a>.
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-relevant"><code>aria-relevant</code></a></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>relevant:&lt;value&gt;</code></span><br>
+					<span class="property">Object Attribute: <code>container-relevant:&lt;value&gt;</code></span><br>
+					<span class="property">Object Attribute: <code>container-relevant:&lt;value&gt;</code> on all descendants</span><br>
+					<span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>AriaProperties.relevant</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>relevant:&lt;value&gt;</code></span><br>
+					<span class="property">Object Attribute: <code>container-relevant:&lt;value&gt;</code></span><br>
+					<span class="property">Object Attribute: <code>container-relevant:&lt;value&gt;</code> on all descendants</span><br>
+					<span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXARIARelevant</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-required"><code>aria-required</code></a>=<code>true</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>IA2_STATE_REQUIRED</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>IsRequiredForForm</code>: <code>true</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_REQUIRED</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXRequired</code>: <code>YES</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-required"><code>aria-required</code></a>=<code>false</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-roledescription"><code>aria-roledescription</code></a></th>
+				<td class="attr-msaa-ia2">
+					<span class="method">Method: <code>localizedExtendedRole()</code>: <code>&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Localized Control Type: <code>&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>roledescription:&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXRoleDescription</code>: <code>&lt;value&gt;</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-roledescription"><code>aria-roledescription</code></a> is empty or whitespace characters</th>
+				<td class="attr-msaa-ia2">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Localized Control Type is defined as that specified for the role of the element: based on the explicit role if the role attribute is provided; otherwise, based on the implicit role for the host language.</span>
+				</td>
+				<td class="attr-atk">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">AXRoleDescription is defined as that specified for the role of the element: based on the explicit role if the role attribute is provided; otherwise, based on the implicit role for the host language.</span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-rowcount"><code>aria-rowcount</code></a></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>rowcount:&lt;value&gt;</code></span><br>
+					<span class="method">Method: <code>IAccessible2::groupPosition()</code>: <code>similarItemsInGroup=&lt;value&gt;</code> on rows</span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>Grid.RowCount</code>: <code>&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>rowcount</code> should contain the author-provided value.</span><br>
+					<span class="method">Method: <code>atk_table_get_n_rows()</code> should return the actual number of rows.</span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXARIARowCount</code>: <code>&lt;value&gt;</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-rowindex"><code>aria-rowindex</code></a></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>rowindex:&lt;value&gt;</code></span><br>
+					<span class="method">Method: <code>IAccessible2::groupPosition()</code>: <code>positionInGroup=&lt;value&gt;</code> on rows</span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>GridItem.Row</code>: <code>&lt;value&gt;</code> (zero-based)</span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>rowindex</code> should contain the author-provided value.</span><br>
+					<span class="method">Method: <code>atk_table_cell_get_position()</code> should return the actual (zero-based) row index.</span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXARIARowIndex</code>: <code>&lt;value&gt;</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-rowindextext"><code>aria-rowindextext</code></a></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>rowindextext:&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>AriaProperties.rowindextext</code>: <code>&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>rowindextext:&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: TBD</span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-rowspan"><code>aria-rowspan</code></a></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>rowspan:&lt;value&gt;</code></span><br>
+					<span class="method">Method: <code>IAccessibleTableCell::rowExtent()</code>: <code>column=&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>GridItem.RowSpan</code>: <code>&lt;value&gt;</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>rowspan</code> should contain the author-provided value.</span><br>
+					<span class="method">Method: <code>atk_table_cell_get_row_column_span()</code> should return the actual row span.</span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXRowIndexRange.length</code>: <code>&lt;value&gt;</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-selected"><code>aria-selected</code></a>=<code>true</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>STATE_SYSTEM_SELECTABLE</code></span><br>
+					<span class="property">State: <code>STATE_SYSTEM_SELECTED</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>SelectionItem.IsSelected</code>: <code>true</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_SELECTABLE</code></span><br>
+					<span class="property">State: <code>STATE_SELECTED</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXSelected</code>: <code>YES</code></span>
+				</td>
+			</tr>
+
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-selected"><code>aria-selected</code></a>=<code>false</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">State: <code>STATE_SYSTEM_SELECTABLE</code></span><br>
+					<span class="property">State: <code>STATE_SYSTEM_SELECTED</code> not exposed</span><br>
+					<span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>SelectionItem.IsSelected</code>: <code>false</code></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">State: <code>STATE_SELECTABLE</code></span><br>
+					<span class="property">State: <code>STATE_SELECTED</code> not exposed</span><br>
+					<span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXSelected</code>: <code>NO</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-selected"><code>aria-selected</code></a> is undefined</th>
+				<td class="attr-msaa-ia2">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-setsize"><code>aria-setsize</code></a></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>setsize:&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>AriaProperties.setsize</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
+				</td>
+				<td class="attr-atk">
+					<p>If the author-provided value of <code>aria-setsize</code> is <code>-1</code>, the exposed value should be based on the number of objects in the <abbr title="Document Object Model">DOM</abbr>.</p>
+					<span class="property">Object Attribute: <code>setsize:&lt;value&gt;</code></span><br>
+					<span class="property">State: <code>STATE_INDETERMINATE</code> if the author-provided value is <code>-1</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXARIASetSize</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-sort"><code>aria-sort</code></a>=<code>ascending</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>sort:ascending</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>AriaProperties.sort</code>: <code>ascending</code></span><br>
+					<span class="property">Property: <code>ItemStatus</code>: <code>ascending</code> if the element maps to <a href="https://msdn.microsoft.com/en-us/library/windows/apps/ee671630.aspx"><code>HeaderItem</code></a> Control Type</span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>sort:ascending</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXSortDirection</code>: <code>AXAscendingSortDirection</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-sort"><code>aria-sort</code></a>=<code>descending</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>sort:descending</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>AriaProperties.sort</code>: <code>descending</code></span><br>
+					<span class="property">Property: <code>ItemStatus</code>: <code>descending</code> if the element maps to <a href="https://msdn.microsoft.com/en-us/library/windows/apps/ee671630.aspx"><code>HeaderItem</code></a> Control Type</span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>sort:descending</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXSortDirection</code>: <code>AXDescendingSortDirection</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-sort"><code>aria-sort</code></a>=<code>other</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>sort:other</code></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>AriaProperties.sort</code>: <code>other</code></span><br>
+					<span class="property">Property: <code>ItemStatus</code>: <code>other</code> if the element maps to <a href="https://msdn.microsoft.com/en-us/library/windows/apps/ee671630.aspx"><code>HeaderItem</code></a> Control Type</span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>sort:other</code></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXSortDirection</code>: <code>AXUnknownSortDirection</code></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-sort"><code>aria-sort</code></a>=<code>none</code></th>
+				<td class="attr-msaa-ia2">
+					<span class="property">Object Attribute: <code>sort:none</code>, if the value is not unspecified</span>
+				</td>
+				<td class="attr-uia">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>sort:none</code>, if the value is not unspecified</span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-valuemax"><code>aria-valuemax</code></a></th>
+				<td class="attr-msaa-ia2">
+					<span class="method">Method: <code>IAccessibleValue::maximumValue()</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="https://w3c.github.io/aria/#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>RangeValue.Maximum</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="https://w3c.github.io/aria/#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="method">Method: <code>atk_value_get_maximum_value()</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="https://w3c.github.io/aria/#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXMaxValue</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="https://w3c.github.io/aria/#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-valuemin"><code>aria-valuemin</code></a></th>
+				<td class="attr-msaa-ia2">
+					<span class="method">Method: <code>IAccessibleValue::minimumValue()</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="https://w3c.github.io/aria/#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>RangeValue.Minimum</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="https://w3c.github.io/aria/#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="method">Method: <code>atk_value_get_minimum_value()</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="https://w3c.github.io/aria/#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXMinValue</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="https://w3c.github.io/aria/#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-valuenow"><code>aria-valuenow</code></a></th>
+				<td class="attr-msaa-ia2">
+					<span class="method">Method: <code>IAccessibleValue::currentValue()</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="method">Method: <code>IAccessible::get_accValue()</code>: <code>&lt;value&gt;</code> if <code>aria-valuetext</code> is not defined</span><br>
+					<span class="seealso">See also: <a href="https://w3c.github.io/aria/#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>RangeValue.Value</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="https://w3c.github.io/aria/#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="method">Method: <code>atk_value_get_current_value()</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="https://w3c.github.io/aria/#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXValue</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="https://w3c.github.io/aria/#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+				</td>
+			</tr>
+			<tr>
+				<th><a class="property-reference" href="https://w3c.github.io/aria/#aria-valuetext"><code>aria-valuetext</code></a></th>
+				<td class="attr-msaa-ia2">
+					<span class="method">Method: <code>IAccessible::get_accValue()</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="property">Object Attribute: <code>valuetext:&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="https://w3c.github.io/aria/#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+				</td>
+				<td class="attr-uia">
+					<span class="property">Property: <code>Value.Value</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="https://w3c.github.io/aria/#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+				</td>
+				<td class="attr-atk">
+					<span class="property">Object Attribute: <code>valuetext:&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="https://w3c.github.io/aria/#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+				</td>
+				<td class="attr-axapi">
+					<span class="property">Property: <code>AXValueDescription</code>: <code>&lt;value&gt;</code></span><br>
+					<span class="seealso">See also: <a href="https://w3c.github.io/aria/#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+				</td>
+			</tr>
+              </tbody>
+            </table>
+          </div>
+  </section>
+	</section>
+	<section id="mapping_additional">
+		<h3 id="x4-6-special-processing-requiring-additional-computation"><bdi class="secno">4.6 </bdi>Special Processing Requiring Additional Computation<a class="self-link" href="#mapping_additional" aria-label="Permalink for Section 4.6"></a></h3>
+		<section id="mapping_additional_nd">
+			<h4 id="x4-6-1-name-and-description"><bdi class="secno">4.6.1 </bdi>Name and Description<a class="self-link" href="#mapping_additional_nd" aria-label="Permalink for Section 4.6.1"></a></h4>
+				<p>For information on how to compute an <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-name">accessible name</a> or <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-description">accessible description</a>, see the section titled <a class="accname" href="https://w3c.github.io/accname/#mapping_additional_nd_te">Accessible Name and Description Computation</a> of the <a class="accname" href="https://w3c.github.io/accname/">Accessible Name and Description Computation</a> specification.</p>
+		</section>
+		<section id="mapping_additional_relations">
+		    <h4 id="x4-6-2-relations"><bdi class="secno">4.6.2 </bdi>Relations<a class="self-link" href="#mapping_additional_relations" aria-label="Permalink for Section 4.6.2"></a></h4>
+	      <p>Often in a <abbr title="Graphical User Interface">GUI</abbr>, there are <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-relationship">relationships</a> between the <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-widget">widgets</a> that can be exposed programmatically to <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-assistive-technology">assistive technology</a>. <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> provides several relationship <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-property">properties</a> which are globally applicable to any <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-element">element</a>: <a class="property-reference" href="https://w3c.github.io/aria/#aria-controls"><code>aria-controls</code></a>, <a class="property-reference" href="https://w3c.github.io/aria/#aria-describedby"><code>aria-describedby</code></a>, <a class="property-reference" href="https://w3c.github.io/aria/#aria-flowto"><code>aria-flowto</code></a>, <a class="property-reference" href="https://w3c.github.io/aria/#aria-labelledby"><code>aria-labelledby</code></a>, <a class="property-reference" href="https://w3c.github.io/aria/#aria-owns"><code>aria-owns</code></a>, <a class="property-reference" href="https://w3c.github.io/aria/#aria-posinset"><code>aria-posinset</code></a>, and <a class="property-reference" href="https://w3c.github.io/aria/#aria-setsize"><code>aria-setsize</code></a>. Therefore, it is not important to check the <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-role">role</a> before computing them. <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-user-agent">User agents</a> can simply map these relations to <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessibility-api">accessibility <abbr title="Application Programming Interfaces">APIs</abbr></a> as defined in the section titled <a href="#mapping_state-property">State and Property Mapping</a>. </p>
+	        <section id="mapping_additional_relations_reverse_relations">
+	        <h5 id="x4-6-2-1-reverse-relations"><bdi class="secno">4.6.2.1 </bdi>Reverse Relations<a class="self-link" href="#mapping_additional_relations_reverse_relations" aria-label="Permalink for Section 4.6.2.1"></a></h5>
+		      <p>A reverse relation exists when an element's ID is referenced by a <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-property">property</a> in another <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-element">element</a>. For <abbr title="Application Programming Interfaces">APIs</abbr> that support reverse relations, <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-user-agent">user agents</a> <em class="rfc2119">MUST</em> use the mapping defined in the <a href="#mapping_state-property_table">State and Property Mapping Table</a> when an element's ID is referenced by a relation property of another element and the referenced element is in the accessibility tree. All <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> references must point to an element that is exposed as an accessible object in the accessibility tree. When the referenced object is not exposed in the accessibility tree (e.g. because it is <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-hidden">hidden</a>), the reference is null. <code>aria-labelledby</code> and <code>aria-describedby</code> have an additional feature, which allows them to pull a flattened string from the referenced element to populate the name or description fields of the accessibility <abbr title="Application Programming Interface">API</abbr>. This feature is described in the <a href="#mapping_additional_nd">Name and Description</a> section.</p>
+            <p>Special case: If both <a class="property-reference" href="https://w3c.github.io/aria/#aria-labelledby"><code>aria-labelledby</code></a> and <abbr title="Hypertext Markup Language">HTML</abbr> <code>&lt;label for= … &gt;</code> are used, the user agent <em class="rfc2119">MUST</em> use the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> relation and <em class="rfc2119">MUST</em> ignore the <abbr title="Hypertext Markup Language">HTML</abbr> label relation.</p>
+            <p>Note that <a class="property-reference" href="https://w3c.github.io/aria/#aria-describedby"><code>aria-describedby</code></a> may reference structured or interactive information where users would want to be able to navigate to different sections of content. User agents <em class="rfc2119">MAY</em> provide a way for the user to navigate to structured information referenced by <a class="property-reference" href="https://w3c.github.io/aria/#aria-describedby"><code>aria-describedby</code></a> and <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-assistive-technology">assistive technology</a> <em class="rfc2119">SHOULD</em> provide such a method.</p>
+        </section>
+        <section id="mapping_additional_relations_implied">
+          <h5 id="x4-6-2-2-implied-reverse-relations"><bdi class="secno">4.6.2.2 </bdi>Implied reverse relations<a class="self-link" href="#mapping_additional_relations_implied" aria-label="Permalink for Section 4.6.2.2"></a></h5>
+			    <p>In addition to the explicit relations defined by <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-property">properties</a>, reverse relations are implied in two other situations: <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-element">elements</a> with <code>role="treeitem"</code> where the ancestor does not have an <a class="property-reference" href="https://w3c.github.io/aria/#aria-owns"><code>aria-owns</code></a> property and descendants of elements with <a class="property-reference" href="https://w3c.github.io/aria/#aria-atomic"><code>aria-atomic</code></a> property.</p>  
+          <p>In the case of <code>role="<a class="role-reference" href="https://w3c.github.io/aria/#treeitem">treeitem</a>"</code>, when <a class="property-reference" href="https://w3c.github.io/aria/#aria-owns"><code>aria-owns</code></a> is not used, <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-user-agent">user agents</a> <em class="rfc2119">SHOULD</em> do the following where reverse relations are supported by the <abbr title="application programming interface">API</abbr>:</p>
+          <ul>
+				    <li>If the current <a class="role-reference" href="https://w3c.github.io/aria/#treeitem"><code>treeitem</code></a> uses <a class="property-reference" href="https://w3c.github.io/aria/#aria-level"><code>aria-level</code></a>, then walk backwards in the tree until a <a class="role-reference" href="https://w3c.github.io/aria/#treeitem"><code>treeitem</code></a> is found with a lower <a class="property-reference" href="https://w3c.github.io/aria/#aria-level"><code>aria-level</code></a>, then set <code>RELATION_NODE_CHILD_OF</code> to that element. If the top of the tree is reached, then set <code>RELATION_NODE_CHILD_OF</code> to the tree element itself.</li>
+				    <li>If the parent of the <a class="role-reference" href="https://w3c.github.io/aria/#treeitem"><code>treeitem</code></a> has a <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-role">role</a> of <a class="role-reference" href="https://w3c.github.io/aria/#group"><code>group</code></a>, then walk backwards from the <a class="role-reference" href="https://w3c.github.io/aria/#group"><code>group</code></a> until an element with a role of  <a class="role-reference" href="https://w3c.github.io/aria/#treeitem"><code>treeitem</code></a> is found, then set <code>RELATION_NODE_CHILD_OF</code> to that element.</li>
+			    </ul>
+          <p>In the case of <a class="property-reference" href="https://w3c.github.io/aria/#aria-atomic"><code>aria-atomic</code></a>, where reverse relations are supported by the <abbr title="application programming interface">API</abbr>:</p> 
+          <ul>
+            <li>User agents <em class="rfc2119">SHOULD</em> check the chain of ancestor elements for <a class="property-reference" href="https://w3c.github.io/aria/#aria-atomic"><code>aria-atomic</code></a><code>="true"</code>. If found, user agents <em class="rfc2119">SHOULD</em> set the <code>RELATION_MEMBER_OF</code> relation to point to the ancestor that sets  <a class="property-reference" href="https://w3c.github.io/aria/#aria-atomic"><code>aria-atomic</code></a><code>="true"</code>.</li>
+			    </ul>
+        </section>
+	  </section>
+	  <section id="mapping_additional_position">
+			<h4 id="x4-6-3-group-position"><bdi class="secno">4.6.3 </bdi>Group Position<a class="self-link" href="#mapping_additional_position" aria-label="Permalink for Section 4.6.3"></a></h4>
+      <p><a class="property-reference" href="https://w3c.github.io/aria/#aria-level"><code>aria-level</code></a>, <a class="property-reference" href="https://w3c.github.io/aria/#aria-posinset"><code>aria-posinset</code></a>, and <a class="property-reference" href="https://w3c.github.io/aria/#aria-setsize"><code>aria-setsize</code></a> are all 1-based. When the <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-property">property</a> is not present or is "0", it indicates the property is not computed or not supported. If any of these properties are specified by the author as either "0" or a negative number, <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-user-agent">user agents</a> <em class="rfc2119">SHOULD</em> use "1" instead. </p>
+			<p>If <a class="property-reference" href="https://w3c.github.io/aria/#aria-level"><code>aria-level</code></a> is not provided or inherited for an element of <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-role">role</a> <a class="role-reference" href="https://w3c.github.io/aria/#treeitem"><code>treeitem</code></a> or <a class="role-reference" href="https://w3c.github.io/aria/#comment"><code>comment</code></a>, user agents implementing IAccessible2 or <abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> <em class="rfc2119">MUST</em> compute it by following the explicit or computed <code>RELATION_NODE_CHILD_OF</code> relations.</p>
+	  <p>If <a class="property-reference" href="https://w3c.github.io/aria/#aria-posinset"><code>aria-posinset</code></a> and <a class="property-reference" href="https://w3c.github.io/aria/#aria-setsize"><code>aria-setsize</code></a> are not provided, user agents <em class="rfc2119">MUST</em> compute them as follows:</p>
+		  <ul>
+				<li>for <code>role="<a class="role-reference" href="https://w3c.github.io/aria/#treeitem">treeitem</a>"</code> and <code>role="<a class="role-reference" href="https://w3c.github.io/aria/#comment">comment</a>"</code>, walk the tree backward and forward until the explicit or computed level becomes less than the current item's level. Count items only if they are at the same level as the current item.</li>
+			  <li>Otherwise, if the role supports <a class="property-reference" href="https://w3c.github.io/aria/#aria-posinset"><code>aria-posinset</code></a> and <a class="property-reference" href="https://w3c.github.io/aria/#aria-setsize"><code>aria-setsize</code></a>, process the parent (<abbr title="Document Object Model">DOM</abbr> parent or parent defined by <a class="property-reference" href="https://w3c.github.io/aria/#aria-owns"><code>aria-owns</code></a>), counting items that have the same role.</li>
+			  <li>Because these value are 1-based, include the current item  in the computation. For <a class="property-reference" href="https://w3c.github.io/aria/#aria-posinset"><code>aria-posinset</code></a>, include the current item and other group items if they are before the current item in the <abbr title="Document Object Model">DOM</abbr>. For <a class="property-reference" href="https://w3c.github.io/aria/#aria-setsize"><code>aria-setsize</code></a>, add to that the number of items in the same group after the current item in the <abbr title="Document Object Model">DOM</abbr>.</li>
+		  </ul>
+      <p>If the author provides one or more of <code>aria-setsize</code> and <code>aria-posinset</code>, it is the author's responsibility to supply them for all elements in the set.  <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-user-agent">User agent</a> correction of missing values in this case is not defined.</p>
+		  <p id="mapping_group_position"><abbr title="Microsoft Active Accessibility">MSAA</abbr>/IAccessible2 <abbr title="Application Programming Interface">API</abbr> mappings involve an additional function, <code>groupPosition()</code> [<cite><a class="bibref" data-link-type="biblio" href="#bib-iaccessible2" title="IAccessible2">IAccessible2</a></cite>], when <a class="property-reference" href="https://w3c.github.io/aria/#aria-level"><code>aria-level</code></a>, <a class="property-reference" href="https://w3c.github.io/aria/#aria-posinset"><code>aria-posinset</code></a>, and/or <a class="property-reference" href="https://w3c.github.io/aria/#aria-setsize"><code>aria-setsize</code></a> are present on an element, or are computed by the user agent. When this occurs: </p>
+		  <ul>
+		    <li><a class="property-reference" href="https://w3c.github.io/aria/#aria-level"><code>aria-level</code></a> is exposed in the <code>groupLevel</code> parameter of <code>groupPosition()</code>,</li>
+		    <li><a class="property-reference" href="https://w3c.github.io/aria/#aria-setsize"><code>aria-setsize</code></a>  is exposed in the <code>similarItemsInGroup</code> parameter, and</li>
+		    <li><a class="property-reference" href="https://w3c.github.io/aria/#aria-posinset"><code>aria-posinset</code></a>  is exposed in the <code>positionInGroup</code> parameter.</li>
+		  </ul>
+    </section>
+	</section>
+  <section id="mapping_actions">
+		<h3 id="x4-7-actions"><bdi class="secno">4.7 </bdi>Actions<a class="self-link" href="#mapping_actions" aria-label="Permalink for Section 4.7"></a></h3>
+    	<p>As part of mapping roles to accessible objects as defined in <a href="#mapping_role">Role Mapping</a>, users  agents expose a default action on the object.</p>
+		  <ul>
+            <li><abbr title="Microsoft Active Accessibility">MSAA</abbr>: If an <abbr title="Assistive Technology">AT</abbr> calls <code>DoDefaultAction</code> on an accessible object, the  user agent <em class="rfc2119">SHOULD</em> simulate a click on the <abbr title="Document Object Model">DOM</abbr> element which is mapped to that  accessible object.</li>
+            <li>IAccessible2: If an <abbr title="Assistive Technology">AT</abbr> calls the <code>IAccessibleAction</code> on an accessible object, the  user agent <em class="rfc2119">SHOULD</em> simulate a click on the <abbr title="Document Object Model">DOM</abbr> element which is mapped to that  accessible object.</li>
+            <li><abbr title="User Interface Automation">UIA</abbr> Automation: If an <abbr title="Assistive Technology">AT</abbr> calls any <abbr title="User Interface Automation">UIA</abbr> pattern method on an accessible object, the  user agent <em class="rfc2119">SHOULD</em> simulate a click on the <abbr title="Document Object Model">DOM</abbr> element which is mapped to that  accessible object.</li>
+            <li><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr>: If an <abbr title="Assistive Technology">AT</abbr> calls an action on an accessible object, the user agent <em class="rfc2119">SHOULD</em> simulate a click on the <abbr title="Document Object Model">DOM</abbr> element which is mapped to  that accessible object.</li>
+            <li><abbr title="macOS Accessibility Protocol">AX API</abbr>: If an <abbr title="Assistive Technology">AT</abbr> triggers an <code>AXPress</code> action on an accessible object, the user   agent <em class="rfc2119">SHOULD</em> simulate a click on the <abbr title="Document Object Model">DOM</abbr> element which is mapped to that   accessible object.</li>
+          </ul>
+      <div class="note" role="note" id="issue-container-generatedID-3"><div role="heading" class="note-title marker" id="h-note-5" aria-level="4"><span>Note</span></div><p class="">Authors will need to create handlers for those click events that update  <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> states and properties in the <abbr title="Document Object Model">DOM</abbr> accordingly, so that those updated states  can be populated by the user agent in the Accessibility <abbr title="Application Programming Interface">API</abbr>.</p></div>
+  </section>
+  <section id="mapping_events">
+		<h3 id="x4-8-events"><bdi class="secno">4.8 </bdi>Events<a class="self-link" href="#mapping_events" aria-label="Permalink for Section 4.8"></a></h3>
+    <p><a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-user-agent">User agents</a> fire <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-event">events</a> for user actions, <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-state">state</a> changes, changes to document content or node visibility, changes in selection and operation of menus as defined in the following sections. </p>
+    <section id="mapping_events_state-change">
+		  <h4 id="x4-8-1-state-and-property-change-events"><bdi class="secno">4.8.1 </bdi>State and Property Change Events<a class="self-link" href="#mapping_events_state-change" aria-label="Permalink for Section 4.8.1"></a></h4>   
+        <p><a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-user-agent">User agents</a> <em class="rfc2119">MUST</em> notify <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-assistive-technology">assistive technology</a> of <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-state">state</a> changes as defined in the table below, <em class="rfc2119">SHOULD</em> notify assistive technology of <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-property">property</a> changes if the <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessibility-api">accessibility <abbr title="Application Programming Interface">API</abbr></a> defines a change <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-event">event</a> for the property, and <em class="rfc2119">SHOULD NOT</em> notify assistive technology of property changes if the accessibility <abbr title="application programming interface">API</abbr> does not define a change event for the property. For example, IAccessible2 defines an event to be used when <a class="property-reference" href="https://w3c.github.io/aria/#aria-activedescendant"><code>aria-activedescendant</code></a> changes. <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> properties that are expected to change include <a class="property-reference" href="https://w3c.github.io/aria/#aria-activedescendant"><code>aria-activedescendant</code></a>, <a class="property-reference" href="https://w3c.github.io/aria/#aria-valuenow"><code>aria-valuenow</code></a>, and <a class="property-reference" href="https://w3c.github.io/aria/#aria-valuetext"><code>aria-valuetext</code></a>.</p>
+        <div class="note" role="note" id="issue-container-generatedID-4"><div role="heading" class="note-title marker" id="h-note-6" aria-level="5"><span>Note</span></div><p class="">In some <abbr title="Application Programming Interfaces">APIs</abbr>, <abbr title="assistive technology">AT</abbr> will only be notified of events to which it has  subscribed.</p></div>
+        <p>For simplicity and  performance the user agent <em class="rfc2119">MAY</em> trim out change events for state or property changes that <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-assistive-technology">assistive technologies</a> typically ignore, such as events that are happening in a window that does not currently have focus.        </p>
+        <div class="note" role="note" id="issue-container-generatedID-5"><div role="heading" class="note-title marker" id="h-note-7" aria-level="5"><span>Note</span></div><p class="">Translators: For label text associated with the following table and its toggle buttons, see the <code>mappingTableLabels</code> object in the <code>&lt;head&gt;</code> section of this document.</p></div>
+        <div class="table-container" style="display: none;">
+        <table class="map-table elements" id="event-mapping-table">
+          <caption>Table of events to be fired in each <abbr title="application programming interface">API</abbr> for changes in <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> states and properties</caption>
+          <thead>
+            <tr>
+              <th>State or Property</th>
+              <th><abbr title="Microsoft Active Accessibility">MSAA</abbr> + IAccessible2 event </th>
+              <th><abbr title="User Interface Automation">UIA</abbr> event</th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
+              <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th><a class="property-reference" href="https://w3c.github.io/aria/#aria-activedescendant"><code>aria-activedescendant</code></a></th>
+              <td>See <a href="#focus_state_event_table">Focus Changes</a>.
+                <p>In addition: </p>
+                <p><code>IA2_EVENT_ACTIVE_DESCENDANT_CHANGED</code></p></td>
+              <td>See <a href="#focus_state_event_table">Focus Changes</a>.
+                <p>In addition:</p>
+                <p><code>PropertyChangedEvent</code></p>
+                <p>Property: <code>AriaProperties</code></p>
+              </td>
+              <td>See <a href="#focus_state_event_table">Focus Changes</a>.</td>
+              <td>See <a href="#focus_state_event_table">Focus Changes</a>.
+                <p>In addition: <code>AXSelectedChildrenChanged</code></p></td>
+              </tr>
+            <tr>
+              <th><a class="state-reference" href="https://w3c.github.io/aria/#aria-busy"><code>aria-busy</code></a> (state)</th>
+              <td><code>EVENT_OBJECT_STATECHANGE</code></td>
+              <td>
+                <code>PropertyChangedEvent</code>
+                <p>Property: <code>AriaProperties</code></p>
+              </td>
+              <td><code>object:state-changed:busy</code></td>
+              <td><code>AXElementBusyChanged</code></td>
+            </tr>            
+          <tr>
+          	<th><a class="state-reference" href="https://w3c.github.io/aria/#aria-checked"><code>aria-checked</code></a> (state)</th>
+              <td><code>EVENT_OBJECT_STATECHANGE</code></td>
+              <td>
+                <code>PropertyChangedEvent</code>
+                <p>Properties: <code>AriaProperties</code>, <code>ToggleState</code> as part of <code>toggle</code> pattern</p>
+              </td>
+              <td><code>object:state-changed:checked</code></td>
+              <td><code>AXValueChanged</code></td>
+            </tr>
+          <tr>
+              <th><a class="state-reference" href="https://w3c.github.io/aria/#aria-current"><code>aria-current</code></a> (state)</th>
+              <td><code>IA2_EVENT_OBJECT_ATTRIBUTE_CHANGED</code></td>
+              <td>
+                <code>PropertyChangedEvent</code>
+                <p>Property: <code>AriaProperties</code></p>
+              </td>
+              <td><code>object:state-changed:active</code></td>
+              <td>No notification</td>
+            </tr>
+              <tr>
+              <th><a class="state-reference" href="https://w3c.github.io/aria/#aria-disabled"><code>aria-disabled</code></a> (state)</th>
+              <td><code>EVENT_OBJECT_STATECHANGE</code></td>
+              <td>
+                <code>PropertyChangedEvent</code>
+                <p>Properties: <code>AriaProperties</code>, <code>IsEnabled</code></p>
+              </td>
+              <td><code>object:state-changed:enabled</code> and  <code>object:state-changed:sensitive</code></td>
+              <td>No notification</td>
+            </tr>
+            <tr>
+	      <th><a class="property-reference" href="https://w3c.github.io/aria/#aria-describedby"><code>aria-describedby</code></a></th>
+	      <td><code>EVENT_OBJECT_DESCRIPTIONCHANGE</code></td>
+	      <td>
+          <code>PropertyChangedEvent</code>
+          <p>Properties: <code>DescribedBy</code></p>
+        </td>
+	      <td><code>object:property-change:accessible-description</code></td>
+	      <td>TBD</td>
+            </tr>
+            <tr>
+                <th><a class="property-reference" href="https://w3c.github.io/aria/#aria-dropeffect"><code>aria-dropeffect</code></a> (property)</th>
+                <td><code>IA2_EVENT_OBJECT_ATTRIBUTE_CHANGED</code></td>
+                <td>
+                  <code>PropertyChangedEvent</code>
+                  <p>Property: <code>AriaProperties</code></p>
+                </td>
+                <td><code>object:property-change</code></td>
+                <td>No notification</td>
+            </tr>
+            <tr>
+              <th><a class="state-reference" href="https://w3c.github.io/aria/#aria-expanded"><code>aria-expanded</code></a> (state)</th>
+              <td><code>EVENT_OBJECT_STATECHANGE</code></td>
+              <td>
+                <code>PropertyChangedEvent</code>
+                <p>Properties: <code>AriaProperties</code>, <code>ExpandCollapseState</code> as part of the <code>ExpandCollapse</code> pattern</p>
+              </td>
+              <td><code>object:state-changed:expanded</code></td>
+              <td><code>AXRowExpanded</code>,<br>
+                  <code>AXRowCollapsed</code>,<br>
+                  <code>AXRowCountChanged</code></td>
+            </tr>
+            <tr>
+              <th><a class="state-reference" href="https://w3c.github.io/aria/#aria-grabbed"><code>aria-grabbed</code></a> (state)</th>
+              <td><p><code>EVENT_OBJECT_SELECTION</code></p>
+                  <p><code>IA2_EVENT_OBJECT_ATTRIBUTE_CHANGED</code></p></td>
+              <td>
+                <code>PropertyChangedEvent</code>
+                <p>Property: <code>AriaProperties</code></p>
+              </td>
+              <td><code>object:property-change</code></td>
+              <td>No notification</td>
+            </tr>
+            <tr>
+              <th><a class="state-reference" href="https://w3c.github.io/aria/#aria-hidden"><code>aria-hidden</code></a> (state)</th>
+              <td><code> IA2_EVENT_OBJECT_ATTRIBUTE_CHANGED</code></td>
+              <td>
+                <code>StructureChangedEvent</code>
+                <p><code>PropertyChangedEvent</code></p>
+                <p>Property: <code>AriaProperties</code></p>
+              </td>
+              <td><code>object:property-change</code></td>
+              <td><code>AXUIElementDestroyed</code>,<br>
+                  <code>AXUIElementCreated</code></td>
+            </tr>
+            <tr>
+              <th><a class="state-reference" href="https://w3c.github.io/aria/#aria-invalid"><code>aria-invalid</code></a> (state)</th>
+              <td><code>EVENT_OBJECT_STATECHANGE</code></td>
+              <td>
+                <code>PropertyChangedEvent</code>
+                <p>Properties: <code>AriaProperties</code>, <code>IsDataValidForForm</code></p>
+              </td>
+              <td><code>object:state-changed:invalid_entry</code></td>
+              <td><code>AXInvalidStatusChanged</code></td>
+            </tr>
+            <tr>
+	      <th><a class="property-reference" href="https://w3c.github.io/aria/#aria-label"><code>aria-label</code></a> and <a class="property-reference" href="https://w3c.github.io/aria/#aria-labelledby"><code>aria-labelledby</code></a></th>
+	      <td><code>EVENT_OBJECT_NAMECHANGE</code></td>
+	      <td>
+          <code>PropertyChangedEvent</code>
+          <p>Property for <code>aria-label</code>: <code>AriaProperties</code></p>
+          <p>Property for <code>aria-labelledby</code>: <code>LabeledBy</code></p>
+				</td>
+	      <td><code>object:property-change:accessible-name</code></td>
+	      <td>TBD</td>
+            </tr>
+            <tr>
+              <th><a class="state-reference" href="https://w3c.github.io/aria/#aria-pressed"><code>aria-pressed</code></a> (state)</th>
+              <td><code>EVENT_OBJECT_STATECHANGE</code></td>
+              <td>
+                <code>PropertyChangedEvent</code>
+                <p>Properties: <code>AriaProperties</code>, <code>ToggleState</code> as part of <code>toggle</code> pattern</p>
+              </td>
+              <td><code>object:state-changed:pressed</code></td>
+              <td>No notification</td>
+            </tr>
+            <tr>
+              <th><a class="property-reference" href="https://w3c.github.io/aria/#aria-readonly"><code>aria-readonly</code></a></th>
+              <td><code>EVENT_OBJECT_STATECHANGE</code></td>
+              <td>
+                <code>PropertyChangedEvent</code>
+                <p>Property: <code>AriaProperties</code></p>
+              </td>
+              <td><code>object:state-changed:readonly</code></td>
+              <td>No notification</td>
+            </tr>
+            <tr>
+              <th><a class="property-reference" href="https://w3c.github.io/aria/#aria-required"><code>aria-required</code></a></th>
+              <td><code>EVENT_OBJECT_STATECHANGE</code></td>
+              <td>
+                <code>PropertyChangedEvent</code>
+                <p>Properties: <code>AriaProperties</code>, <code>IsRequiredForForm</code></p>
+              </td>
+              <td><code>object:state-changed:required</code></td>
+              <td>No notification</td>
+            </tr>
+            <tr>
+              <th><a class="property-reference" href="https://w3c.github.io/aria/#aria-selected"><code>aria-selected</code></a> (state)</th>
+              <td>See section <a href="#mapping_events_selection">Selection</a> for details.  </td>
+              <td>See section <a href="#mapping_events_selection">Selection</a> for details.  </td>
+              <td>See section <a href="#mapping_events_selection">Selection</a> for details.  </td>
+              <td>See section <a href="#mapping_events_selection">Selection</a> for details.  </td>
+            </tr>
+            <tr>
+              <th><a class="property-reference" href="https://w3c.github.io/aria/#aria-valuenow"><code>aria-valuenow</code></a></th>
+              <td><code>EVENT_OBJECT_VALUECHANGE</code></td>
+              <td>
+                <code>PropertyChangedEvent</code>
+                <p>Properties: <code>AriaProperties</code>, also <code>RangeValueValue</code> if element is mapped with <code>RangeValue</code> Control Pattern</p>
+              </td>
+              <td><code>object:property-change:accessible-value</code></td>
+              <td><code>AXValueChanged</code></td>
+            </tr>
+            <tr>
+              <th><a class="property-reference" href="https://w3c.github.io/aria/#aria-valuetext"><code>aria-valuetext</code></a></th>
+              <td><code>EVENT_OBJECT_VALUECHANGE</code></td>
+              <td>
+                <code>PropertyChangedEvent</code>
+                <p>Property: <code>AriaProperties</code></p>
+              </td>
+              <td><code>object:property-change:accessible-value</code></td>
+              <td><code>AXValueChanged</code></td>
+            </tr>
+          </tbody>
+        </table>
+</div>
+        </section>
+    <section id="mapping_events_visibility">
+		  <h4 id="x4-8-2-changes-to-document-content-or-node-visibility"><bdi class="secno">4.8.2 </bdi>Changes to document content or node visibility<a class="self-link" href="#mapping_events_visibility" aria-label="Permalink for Section 4.8.2"></a></h4>
+		  <p>Processing document changes is important regardless of <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr>. The events described in the table below are used by user agents to inform <abbr title="assistive technology">AT</abbr> of changes to the <abbr title="Document Object Model">DOM</abbr> via the accessibility tree. For the purposes of conformance with this standard, <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-user-agent">user agents</a> <em class="rfc2119">MUST</em> implement the behavior described in this section whenever <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> attributes are applied to dynamic content on a Web page.        </p>
+		  <table>
+          <caption>Table of document change scenarios and events to be fired in each <abbr title="application programming interface">API</abbr></caption>
+          <tbody>
+            <tr>
+              <th>Scenario</th>
+              <th><abbr title="Microsoft Active Accessibility">MSAA</abbr> + IAccessible2 event </th>
+              <th><abbr title="User Interface Automation">UIA</abbr> event</th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
+              <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
+            </tr>
+            <tr>
+              <th>When text is removed</th>
+              <td><code>IA2_EVENT_TEXT_REMOVED</code></td>
+              <td><code>EVENT_OBJECT_LIVEREGIONCHANGED</code></td>
+              <td><code>text_changed::delete</code></td>
+              <td>If in a <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-live-region">live region</a>, <code>AXLiveRegionChanged</code>.<br>If in <code>aria-errormessage</code>, <code>AXValidationErrorChanged</code>.</td>
+            </tr>
+            <tr>
+              <th>When text is inserted</th>
+              <td><code>IA2_EVENT_TEXT_INSERTED</code></td>
+              <td><code>EVENT_OBJECT_LIVEREGIONCHANGED</code></td>
+              <td><code>text_changed::insert</code></td>
+              <td>If in a <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-live-region">live region</a>, <code>AXLiveRegionChanged</code>.<br>If in <code>aria-errormessage</code>, <code>AXValidationErrorChanged</code>.</td>
+            </tr>
+            <tr>
+              <th>When text is changed</th>
+              <td><code>IA2_EVENT_TEXT_REMOVE</code> and <code>IA2_EVENT_TEXT_INSERTED</code></td>
+              <td><code>EVENT_OBJECT_LIVEREGIONCHANGED</code></td>
+              <td><code>text_changed::delete</code> and <code>text_changed::insert</code></td>
+              <td>If in a <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-live-region">live region</a>, <code>AXLiveRegionChanged</code>.<br>If in <code>aria-errormessage</code>, <code>AXValidationErrorChanged</code>.</td>
+            </tr>
+          </tbody>
+        </table>
+		<p>Fire these events for node changes where the node in question is an element and has an <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-object">accessible object</a>:</p>
+        <table>
+          <caption>Table of document change scenarios and events to be fired in each <abbr title="application programming interface">API</abbr></caption>
+          <tbody>
+            <tr>
+              <th>Scenario</th>
+              <th><abbr title="Microsoft Active Accessibility">MSAA</abbr></th>
+              <th>Microsoft <abbr title="User Interface Automation">UIA</abbr> event</th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
+              <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
+            </tr>
+            <tr>
+              <th>When an <a class="termref informative internalDFN" href="#dfn-accessibility-subtree" data-link-type="dfn" id="ref-for-dfn-accessibility-subtree-1">accessibility subtree</a> is <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-hidden">hidden</a></th>
+              <td><code>EVENT_OBJECT_HIDE</code><br>
+                  The <abbr title="Microsoft Active Accessibility">MSAA</abbr> event called <code>EVENT_OBJECT_DESTROY</code> is not used because this has a history of  stability issues and assistive technology avoids it. In any case, from the user's point  of view, there is no difference between something that is hidden or  destroyed.
+              </td>
+              <td><code>AutomationElement..::.StructureChangedEvent</code></td>
+              <td><code>children_changed::remove</code></td>
+              <td><p><code>AXUIElementDestroyed</code></p>
+                    <p>If in a live region, <code>AXLiveRegionChanged</code></p></td>
+            </tr>
+            <tr>
+              <th>When an accessibility subtree is removed</th>
+              <td><code>EVENT_OBJECT_REORDER</code><br>
+                  The <abbr title="Microsoft Active Accessibility">MSAA</abbr> event called <code>EVENT_OBJECT_DESTROY</code> is not used because this has a history of  stability issues and assistive technology avoids it. In any case, from the user's point  of view, there is no difference between something that is hidden or  destroyed.
+              </td>
+              <td><code>AutomationElement..::.StructureChangedEvent</code></td>
+              <td><code>children_changed::remove</code></td>
+              <td><p><code>AXUIElementDestroyed</code></p>
+                  <p>If in a live region, <code>AXLiveRegionChanged</code></p></td>
+            </tr>
+            <tr>
+              <th>When an accessibility subtree is shown</th>
+              <td><code>EVENT_OBJECT_SHOW</code></td>
+              <td>&nbsp;</td>
+              <td><code>children_changed::add</code></td>
+              <td><p><code>AXUIElementCreated</code></p>
+                  <p>If in a live region, <code>AXLiveRegionChanged</code></p></td>
+            </tr>
+            <tr>
+              <th>When an accessibility subtree is inserted</th>
+              <td><code>EVENT_OBJECT_REORDER</code></td>
+              <td>&nbsp;</td>
+              <td><code>children_changed::add</code></td>
+              <td><p><code>AXUIElementCreated</code></p>
+                  <p>If in a live region, <code>AXLiveRegionChanged</code></p></td>
+            </tr>
+            <tr>
+              <th>When an accessibility subtree is moved</th>
+              <td>Treat it as a removal from one place and insertion in another</td>
+              <td>Treat it as a removal from one place and insertion in another</td>
+              <td>Treat it as a removal from one place and insertion in another</td>
+              <td><p><code>AXUIElementDestroyed</code>/ <code>AXUIElementCreated</code></p>
+                  <p>If in a live region, <code>AXLiveRegionChanged</code></p></td>
+            </tr>
+            <tr>
+              <th>When an accessibility subtree is changed (e.g. replaceNode)</th>
+              <td>Treat it as a removal and insertion</td>
+              <td>Treat it as a removal and insertion</td>
+              <td>Treat it as a removal and insertion</td>
+              <td><p><code>AXUIElementDestroyed</code>/ <code>AXUIElementCreated</code></p>
+                  <p>If in a live region, <code>AXLiveRegionChanged</code></p></td>
+            </tr>
+          </tbody>
+        </table>
+	  <p>In some cases, node changes may occur where the node is not an element or has no accessible object. For example, a numbered list bullet ("12.") may have a node in the accessibility tree but not in the <abbr title="Document Object Model">DOM</abbr> tree. For text within a paragraph marked in <abbr title="Hypertext Markup Language">HTML</abbr> as <code>&lt;strong&gt;</code>, the  <code>&lt;strong&gt;</code> element has a node in the  <abbr title="Document Object Model">DOM</abbr> tree but may not have one in the accessibility tree. The text itself will of course be in the accessibility tree along with the identification of the range of text that is formatted as strong. If any of the changes described in the table above occur on such a node, user agents <em class="rfc2119">SHOULD</em> compute and fire relevant text change events as described above. </p>
+    <p>User agents <em class="rfc2119">SHOULD</em> ensure that an assistive technology, running in process can receive notification of a node being removed prior to removal. This allows an assistive technology, such as a screen reader, to refer back to the corresponding <abbr title="Document Object Model">DOM</abbr> node being deleted. This is important for <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-live-region">live regions</a> where removals are important. For example, a screen reader would want to notify a user that another user has left a chat room. The event in <abbr title="Microsoft Active Accessibility">MSAA</abbr> would be<code> EVENT_OBJECT_HIDE</code>. For <abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr> this would be <code>children_changed::remove</code>. And in macOS, the event is <code>AXLiveRegionChanged</code>. This also requires the user agent to provide a unique ID in the <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessibility-api">accessibility <abbr title="Application Programming Interface">API</abbr></a> notification identifying the unique node being removed.</p>
+		<p>When firing any of the above-mentioned change events, it is very  useful to provide information about whether the change was caused by  user input (as opposed to a timeout initiated from the page load,  etc.). This allows the assistive technology to have different rules for presenting  changes from the real world as opposed to from user action. Mouse  hovers are not considered explicit user input because they can occur  from accidental bumps of the mouse.</p>
+	  <p>To expose whether a change occurred from user input:</p>
+		<ul>
+			<li>In <abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr> this can be provided by appending the string ":system" to the event name when the user did not cause the change.</li>
+			<li>In  IAccessible2, which screen readers typically access in process on the same  thread, the best practice is to expose the object attribute <code>event-from-user-input:true</code> on the accessible object for the event, if  the user caused the change.</li>
+		</ul>
+		<p>Exposing additional useful information about the context of the change:</p>
+		<ul>
+			<li>In <abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr> and IAccessible2, the <code>RELATION_MEMBER_OF</code> relation on the accessible event's target accessible object <em class="rfc2119">SHOULD</em> point to any ancestor with <a class="property-reference" href="https://w3c.github.io/aria/#aria-atomic"><code>aria-atomic</code></a><code>="true"</code> (if any).</li>
+			<li>In <abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr> and IAccessible2, the  <code>container-live</code>, <code>container-relevant</code>, <code>container-busy</code>,  <code>container-atomic</code> object attributes <em class="rfc2119">SHOULD</em> be exposed on the accessible  event object, providing the computed value for the related <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr>  properties. The computed value is the value of the closest ancestor. It  is recommended to not expose the object attribute if the default value  is used.</li>
+		</ul>
+    <p>Additional <abbr title="Microsoft Active Accessibility">MSAA</abbr> events may be necessary:</p>
+		<ul>
+			<li>If something changes in an ancestor with a mapped <abbr title="Microsoft Active Accessibility">MSAA</abbr> role of <code>ROLE_SYSTEM_ALERT</code>, then an <code>EVENT_SYSTEM_ALERT</code> event <em class="rfc2119">SHOULD</em> be fired for  the alert. The alert role has an implied value of "assertive" for the <a class="property-reference" href="https://w3c.github.io/aria/#aria-live"><code>aria-live</code></a> property.</li>
+			<li>Menu events may need to be fired. See <a href="#mapping_events_menus">Special Events for Menus</a>.</li>
+		</ul>
+    </section>
+    <section id="focus_state_event_table">
+      <h4 id="x4-8-3-focus-changes"><bdi class="secno">4.8.3 </bdi>Focus Changes<a class="self-link" href="#focus_state_event_table" aria-label="Permalink for Section 4.8.3"></a></h4>
+      <p>The following table defines the accessibility <abbr title="Application Programming Interface">API</abbr> keyboard focus states and events.</p>
+      <table>
+	<caption>Table of <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessibility-api">accessibility <abbr title="application programming interface">APIs</abbr></a> for focus states and <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-event">events</a></caption>
+	<tbody><tr>
+	  <th>&nbsp;</th>
+	  <th><abbr title="Microsoft Active Accessibility">MSAA</abbr></th>
+	  <th>Microsoft <abbr title="User Interface Automation">UIA</abbr></th>
+	  <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+	  <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+	</tr>
+	<tr>
+	  <th>Focusable state</th>
+	  <td><code>STATE_SYSTEM_FOCUSABLE</code></td>
+	  <td>Current state reflected in <code>IUIAutomationElement::CurrentIsKeyboardFocusable</code>, can be retrieved with <code>IUIAutomationElement::GetCurrentPropertyValue</code> method using <code>UIA_IsKeyboardFocusablePropertyId</code> property identifier.</td>
+	  <td><code>STATE_FOCUSABLE</code></td>
+	  <td><code>boolean AXFocused</code>: the <code>AXUIElementIsAttributeSettable</code> method returns <code>YES</code>.</td>
+	</tr>
+	<tr>
+	  <th>Focused state</th>
+	  <td><code>STATE_SYSTEM_FOCUSED</code></td>
+	  <td>Current state reflected in <code>IUIAutomationElement::CurrentHasKeyboardFocus</code>, can be retrieved with <code>IUIAutomationElement::GetCurrentPropertyValue</code> method using <code>UIA_HasKeyboardFocusPropertyId</code> property identifier.</td>
+	  <td><code>STATE_FOCUSED</code></td>
+	  <td><code>boolean AXFocused</code></td>
+	</tr>
+	<tr>
+	  <th>Focus event</th>
+	  <td><code>EVENT_OBJECT_FOCUS</code></td>
+	  <td>Clients can subscribe with <code>IUIAutomation::AddFocusChangedEventHandler</code> using callback interface is <code>IUIAutomationFocusChangedEventHandler</code></td>
+	  <td><code>object:state-changed:focused</code> and:
+	    <ul>
+	      <li><code>detail1 = 1</code> for the <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-object">accessible object</a> which just gained focus.</li>
+	      <li><code>detail1 = 0</code> for the <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-object">accessible object</a> which just lost focus.</li>
+	    </ul>
+	  </td>
+	  <td><code>AXFocusedUIElementChanged</code></td>
+	</tr>
+      </tbody></table>
+    </section>
+    <section id="mapping_events_selection">
+		  <h4 id="x4-8-4-selection"><bdi class="secno">4.8.4 </bdi>Selection<a class="self-link" href="#mapping_events_selection" aria-label="Permalink for Section 4.8.4"></a></h4>
+		  <p>There are two cases for selection:</p>
+		  <ul>
+			  <li>Single selection</li>
+			  <li>Multiple selection</li>
+		  </ul>
+      <p>In the single selection case, selection follows focus (see the section "<a href="#focus_state_event_table">Focus States and Events Table</a>" for information about focus events). User agents <em class="rfc2119">MUST</em> fire the following events when <a class="state-reference" href="https://w3c.github.io/aria/#aria-selected"><code>aria-selected</code></a> changes:</p>
+      <table>
+        <caption>Single selection events</caption>
+	      <tbody>
+				<tr>
+					<th>Scenario</th>
+					<th><abbr title="Microsoft Active Accessibility">MSAA</abbr></th>
+					<th>Microsoft <abbr title="User Interface Automation">UIA</abbr></th>
+					<th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+					<th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+				</tr>
+				<tr>
+					<th>Focus change</th>
+					<td><code>EVENT_OBJECT_SELECTION</code> and <code>EVENT_OBJECT_STATECHANGE</code> on newly focused item.</td>
+					<td><code>UIA_SelectionItem_ElementSelectedEventId</code> on the newly focused element.
+					    <p>If on a <code>gridcell</code>, <code>row</code>, <code>option</code>, or <code>tab</code>, fire <code>UIA_SelectionItem_ElementSelectedEventId</code>.</p></td>
+					<td>
+					  <ul>
+					    <li><code>object:selection-changed</code> on the current container,</li>
+					    <li><code>object:state-changed:selected</code> on the descendant <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-object">accessible object</a> whose selection has changed:
+					      <ul>
+					        <li><code>detail1 = 1</code> for the descendant which just became selected.</li>
+					        <li><code>detail1 = 0</code> for the descendant which just became unselected.</li>
+					      </ul>
+					    </li>
+					  </ul>
+					</td>
+					<td><code>AXSelectedChildrenChanged</code></td>
+				</tr>
+        </tbody>
+      </table>
+    <p>The multiple selection case occurs when <a class="property-reference" href="https://w3c.github.io/aria/#aria-multiselectable"><code>aria-multiselectable</code></a><code>="true"</code>  on an <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-element">element</a> with a <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-role">role</a> that supports that <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-property">property</a>.  User agents <em class="rfc2119">MUST</em> fire the following events when <a class="state-reference" href="https://w3c.github.io/aria/#aria-selected"><code>aria-selected</code></a> changes on a descendant, as follows:</p>
+    <p>The multiple selection case occurs when <a class="property-reference" href="https://w3c.github.io/aria/#aria-multiselectable"><code>aria-multiselectable</code></a><code>="true"</code>  on an <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-element">element</a> with a <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-role">role</a> that supports that <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-property">property</a>. There are  several important aspects:</p>
+		<ol>
+			<li>In Microsoft <abbr title="User Interface Automation">UIA</abbr>, the <code>Selection</code> and <code>SelectionItem</code> Control Patterns expose the selection availability, state, and methods.</li>
+			<li>User agents <em class="rfc2119">MUST</em> fire the following events when <a class="state-reference" href="https://w3c.github.io/aria/#aria-selected"><code>aria-selected</code></a> changes on a descendant, as follows:</li>
+		</ol>
+		<table>
+		  <caption>Multiple selection events</caption>
+      <tbody>
+				<tr>
+					<th>Scenario</th>
+					<th><abbr title="Microsoft Active Accessibility">MSAA</abbr></th>
+					<th>Microsoft <abbr title="User Interface Automation">UIA</abbr></th>
+					<th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+					<th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+				</tr>
+				<tr>
+					<th>Toggle <a class="state-reference" href="https://w3c.github.io/aria/#aria-selected"><code>aria-selected</code></a></th>
+					<td><code>EVENT_OBJECT_SELECTIONADD</code>/<code>EVENT_OBJECT_SELECTIONREMOVE</code> on the item.</td>
+					<td><code>SelectionItem Control Pattern</code>:<code>UIA_SelectionItem_ElementAddedToSelectionEventId</code> or <code>UIA_SelectionItem_ElementRemovedFromSelectionEventId</code> on the item.</td>
+					<td>
+					    <ul>
+					      <li><code>object:selection-changed</code> on the current container,</li>
+					      <li><code>object:state-changed:selected</code> on any descendant <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-object">accessible object</a> whose selection has changed:
+						    <ul>
+					          <li><code>detail1 = 1</code> for any descendant which just became selected.</li>
+					          <li><code>detail1 = 0</code> for any descendant which just became unselected.</li>
+					        </ul>
+					      </li>
+					    </ul>
+					</td>
+					<td><code>AXSelectedChildrenChanged</code></td>
+				</tr>
+				<tr>
+					<th>Selection follows focus</th>
+					<td><code>EVENT_OBJECT_SELECTION</code> and <code>EVENT_OBJECT_STATECHANGE</code> on newly focused item.</td>
+					<td><code>FocusChangedEvent</code> should be fired but individual selection event may not happen, to avoid redundancy.</td>
+					<td>
+					    <ul>
+					      <li><code>object:selection-changed</code> on the current container,</li>
+					      <li><code>object:state-changed:selected</code> on any descendant <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-object">accessible object</a> whose selection has changed:
+						    <ul>
+					          <li><code>detail1 = 1</code> for any <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-object">accessible object</a> which just became selected.</li>
+					          <li><code>detail1 = 0</code> for any <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-object">accessible object</a> which just became unselected.</li>
+					        </ul>
+					      </li>
+					    </ul>
+					</td>
+					<td><code>AXSelectedChildrenChanged</code></td>
+				</tr>
+				<tr>
+					<th>Select or deselect many items at once</th>
+					<td>User agent <em class="rfc2119">MAY</em> fire an <code>EVENT_OBJECT_SELECTIONWITHIN</code>. If this event is fired the other events noted above <em class="rfc2119">MAY</em> be trimmed out for performance.</td>
+					<td>For each element selected or deselected, fire <code>SelectionItem</code> Control   Pattern: <code>UIA_SelectionItem_ElementAddedToSelectionEventId</code> or   <code>UIA_SelectionItem_ElementRemovedFromSelectionEventId</code> on the current   container.  User agents <em class="rfc2119">MAY</em> choose to fire the Selection Control Pattern   Invalidated event, which indicates that the selection in a container   has changed significantly and requires sending more addition and removal   events than the <code>InvalidateLimit</code> constant permits.</td>
+					<td>
+					    <ul>
+					      <li>the user agent <em class="rfc2119">MAY</em> fire a single <code>object:selection-changed</code> event on the container, vs. multiple events, for performance,</li>
+					      <li><code>object:state-changed:selected</code> on any descendant <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-object">accessible object</a> whose selection has changed:
+					        <ul>
+					          <li><code>detail1 = 1</code> for any <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-object">accessible object</a> which just became selected.</li>
+					          <li><code>detail1 = 0</code> for any <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-object">accessible object</a> which just became unselected.</li>
+					        </ul>
+					      </li>
+					    </ul>
+					</td>
+					<td><code>AXSelectedChildrenChanged</code></td>
+				</tr>
+			</tbody>
+		</table>
+	</section>
+	  <section id="mapping_events_menus">
+	    <h4 id="x4-8-5-special-events-for-menus"><bdi class="secno">4.8.5 </bdi>Special Events for Menus<a class="self-link" href="#mapping_events_menus" aria-label="Permalink for Section 4.8.5"></a></h4>
+		  <p>Some <abbr title="Application Programming Interfaces">APIs</abbr>, provide special <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-event">events</a> whenever a menu is opened or closed.  <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-user-agent">User agents</a> <em class="rfc2119">SHOULD</em> provide the events as described in the table below.  If provided, because menus can be made visible or <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-hidden">hidden</a> using a variety of techniques, a <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-user-agent">user agent</a> <em class="rfc2119">MUST</em> ensure that the events are nested and symmetrical. </p>
+		  <p>Frequently, a <a class="role-reference" href="https://w3c.github.io/aria/#menubar"><code>menubar</code></a> is used to organize a hierarchy of menus.  In those cases, the menubar <em class="rfc2119">MUST</em> be a <abbr title="Document Object Model">DOM</abbr> parent of the associated <a class="role-reference" href="https://w3c.github.io/aria/#menuitem"><code>menuitem</code></a>s, or one defined by <a class="property-reference" href="https://w3c.github.io/aria/#aria-owns"><code>aria-owns</code></a>.  In other cases, no menubar is involved; for example, when the <a class="role-reference" href="https://w3c.github.io/aria/#menu"><code>menu</code></a> is associated with a toolbar button, or is a context menu. Nonetheless the relevant menu events are provided as described in the following table. </p>
+     <table>
+      <caption>Menu events</caption>
+			<tbody>
+				<tr>
+					<th>Scenario</th>
+					<th><abbr title="Microsoft Active Accessibility">MSAA</abbr></th>
+          <th>Microsoft <abbr title="User Interface Automation">UIA</abbr></th>
+          <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+        </tr>
+				<tr>
+					<td><p>Menubar is currently not active, and user moves focus to the menubar from elsewhere thereby activating it.  As a result, a menuitem in the menubar is focused.  </p></td>
+					<td>Activate the menubar and fire <code>EVENT_SYSTEM_MENUSTART</code> on the accessible object for the menubar.</td>
+					<td><code>MenuModeStartEvent</code> on the accessible object for the menu.</td>
+          <td><code>AXMenuOpenedNotification</code></td>
+        </tr>
+        <tr>
+          <td><p>Focus a menuitem while menubar is activated, or focus a menuitem in a menu.</p></td>
+          <td><code>EVENT_OBJECT_FOCUS</code></td>
+          <td><code>AutomationFocusChangedEvent</code></td>
+          <td><code>AXMenuItemSelectedNotification</code></td>
+        </tr>
+				<tr>
+				  <td><p>Menu popup made visible (menu is opened).</p>
+              <p>Should only be fired once until the menu is closed and opened again.</p> </td>
+				  <td><code>EVENT_SYSTEM_MENUPOPUPSTART</code></td>
+					<td><code>MenuOpenedEvent</code>, then a <code>focus</code> event on a menuitem.</td>
+          <td><code>AXMenuOpenedNotification</code></td>
+        </tr>
+				<tr>
+					<td>Menu popup hidden (menu is closed).</td>
+					<td><code>EVENT_SYSTEM_MENUPOPUPEND</code> once only for accessible menu object and only if <code>EVENT_SYSTEM_MENUPOPUPSTART</code> was fired for it.</td>
+					<td><code>MenuClosedEvent</code></td>
+          <td><code>AXMenuClosedNotification</code></td>
+        </tr>
+        <tr>
+          <td>Any open menus are closed including sub-menus, and user moves focus away from the menubar; menubar is deactivated.</td>
+          <td><code>EVENT_SYSTEM_MENUEND</code> on the menubar and deactivate the menubar.</td>
+          <td><code>MenuClosedEvent</code>, then <code>MenuModeEndEvent</code></td>
+          <td><code>AXMenuClosedNotification</code></td>
+        </tr>
+			</tbody>
+		</table>
+    </section>
+  </section>
+</section>
+
+	<section class="appendix" id="changelog">
+		<h2 id="a-change-log"><bdi class="secno">A. </bdi>Change Log<a class="self-link" href="#changelog" aria-label="Permalink for Appendix A."></a></h2>
+		<section id="substantive-changes-since-the-last-public-working-draft">
+		<h3 id="a-1-substantive-changes-since-the-last-public-working-draft"><bdi class="secno">A.1 </bdi>Substantive changes since the last public working draft<a class="self-link" href="#substantive-changes-since-the-last-public-working-draft" aria-label="Permalink for Appendix A.1"></a></h3>
+		<ul>
+			
+			<li>05-Apr-2021: Update <abbr title="Accessibility Toolkit">ATK</abbr> mappings for <code>aria-colindex</code>, <code>aria-colspan</code>, <code>aria-colcount</code>, <code>aria-rowindex</code>, <code>aria-rowspan</code>, and <code>aria-rowcount</code>.</li>
+			<li>06-Apr-2020: Update <abbr title="Accessibility Toolkit">ATK</abbr> mappings for <code>alert</code> and <code>alertdialog</code>.</li>
+			<li>25-Feb-2020: Add mappings for <code>comment</code>, <code>mark</code>, and <code>suggestion</code> roles. Include <code>comment</code> in calculation for <code>aria-label</code> and group position.</li>
+			<li>25-Feb-2020: Add mappings for <code>aria-description</code>.</li>
+			<li>03-Nov-2019: Remove explicit AXRoleDescription values for <abbr title="macOS Accessibility Protocol">AX API</abbr>. User agents should follow the guidance described in the note.</li>
+			<li>22-Oct-2019: Add mappings for <code>strong</code> and <code>emphasis</code> roles for <abbr title="macOS Accessibility Protocol">AX API</abbr>.</li>
+			<li>22-Oct-2019: Add mappings for <code>code</code> role for <abbr title="macOS Accessibility Protocol">AX API</abbr>.</li>
+			<li>21-Oct-2019: Add mappings for <code>aria-colindextext</code> and <code>aria-rowindextext</code> roles for <abbr title="Accessibility Toolkit">ATK</abbr>, IA2, and <abbr title="User Interface Automation">UIA</abbr>.</li>
+			<li>21-Oct-2019: Add mappings for <code>strong</code> and <code>emphasis</code> roles for <abbr title="Accessibility Toolkit">ATK</abbr>, IA2, and <abbr title="User Interface Automation">UIA</abbr>.</li>
+			<li>21-Oct-2019: Add mappings for <code>code</code> role for <abbr title="Accessibility Toolkit">ATK</abbr>, IA2, and <abbr title="User Interface Automation">UIA</abbr>.</li>
+			<li>18-Sep-2019: Update <abbr title="Microsoft Active Accessibility">MSAA</abbr> mappings for <code>subscript</code> and <code>superscript</code></li>
+			<li>10-Sep-2019: Add mappings for <code>generic</code> role.</li>
+			<li>09-Jul-2019: Add mappings for <code>insertion</code> and <code>deletion</code> roles.</li>
+			<li>14-May-2019: Add mappings for <code>legend</code> role.</li>
+			<li>14-May-2019: Add mappings for <code>label</code> role.</li>
+			<li>14-May-2019: Add mappings for <code>time</code> role.</li>
+			<li>25-Apr-2019: Add mappings for <code>subscript</code> and <code>superscript</code> roles.</li>
+			<li>25-Feb-2019: Add mappings for <code>meter</code> role.</li>
+		        <li>05-Feb-2019: Update <abbr title="User Interface Automation">UIA</abbr> state and property change events.</li>
+			<li>06-Jun-2018: Update <abbr title="User Interface Automation">UIA</abbr> mappings for <code>aria-placeholder</code>.</li>
+			<li>04-Jun-2018: Add mappings for <code>blockquote</code>, <code>caption</code>, and <code>paragraph</code> roles.</li>
+			<li>05-Mar-2018: Add mention of <code>AXTitle</code> for exposing rendered labels for AXAPI.</li>
+			<li>05-Mar-2018: Add events for <code>aria-label</code>, <code>aria-labelledby</code>, and <code>aria-describedby</code>.</li>
+		</ul>
+	</section>
+	<section id="substantive-changes-since-the-core-accessibility-api-mappings-1-1-recommendation">
+		<h3 id="a-2-substantive-changes-since-the-core-accessibility-api-mappings-1-1-recommendation"><bdi class="secno">A.2 </bdi>Substantive changes since the <a href="https://www.w3.org/TR/core-aam-1.1/">Core Accessibility <abbr title="Application Programming Interface">API</abbr> Mappings 1.1 Recommendation</a><a class="self-link" href="#substantive-changes-since-the-core-accessibility-api-mappings-1-1-recommendation" aria-label="Permalink for Appendix A.2"></a></h3>
+		<ul>
+			
+		</ul>
+	</section>
+	</section>
+	<section class="appendix informative section" id="acknowledgements">
+		<h2 id="b-acknowledgments"><bdi class="secno">B. </bdi>Acknowledgments<a class="self-link" href="#acknowledgements" aria-label="Permalink for Appendix B."></a></h2><p><em>This section is non-normative.</em></p>
+		<p>The following people contributed to the development of this document.</p>
+		<div data-include="common/acknowledgements/aria-wg-active.html" data-include-replace="true" data-include-id="include-36670229935429033" class="respec-offending-element" title="`data-include` failed: `common/acknowledgements/aria-wg-active.html` (Failed to fetch)." id="respec-offender-data-include-failed-common-acknowledgements-aria-wg-active-html-failed-to-fetch"></div>
+		<div data-include="common/acknowledgements/aria-contributors.html" data-include-replace="true" data-include-id="include-341544103697361" class="respec-offending-element" title="`data-include` failed: `common/acknowledgements/aria-contributors.html` (Failed to fetch)." id="respec-offender-data-include-failed-common-acknowledgements-aria-contributors-html-failed-to-fetch"></div>
+		<div data-include="common/acknowledgements/funders.html" data-include-replace="true" data-include-id="include-8735172548650381" class="respec-offending-element" title="`data-include` failed: `common/acknowledgements/funders.html` (Failed to fetch)." id="respec-offender-data-include-failed-common-acknowledgements-funders-html-failed-to-fetch"></div>
+	</section>
+
+
+<section id="references" class="appendix"><h2 id="c-references"><bdi class="secno">C. </bdi>References<a class="self-link" href="#references" aria-label="Permalink for Appendix C."></a></h2><section id="normative-references">
+    <h3 id="c-1-normative-references"><bdi class="secno">C.1 </bdi>Normative references<a class="self-link" href="#normative-references" aria-label="Permalink for Appendix C.1"></a></h3>
+    <dl class="bibliography"><dt id="bib-iaccessible2">[IAccessible2]</dt><dd><a href="https://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2"><cite>IAccessible2</cite></a>.  Linux Foundation. URL: <a href="https://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2">https://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2</a></dd><dt id="bib-rfc2119">[RFC2119]</dt><dd><a href="https://www.rfc-editor.org/rfc/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. S. Bradner.  IETF. March 1997. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc2119">https://www.rfc-editor.org/rfc/rfc2119</a></dd><dt id="bib-rfc8174">[RFC8174]</dt><dd><a href="https://www.rfc-editor.org/rfc/rfc8174"><cite>Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</cite></a>. B. Leiba.  IETF. May 2017. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc8174">https://www.rfc-editor.org/rfc/rfc8174</a></dd><dt id="bib-wai-aria-1.2">[WAI-ARIA-1.2]</dt><dd><a href="https://www.w3.org/TR/wai-aria-1.2/"><cite>Accessible Rich Internet Applications (WAI-ARIA) 1.2</cite></a>. Joanmarie Diggs; James Nurthen; Michael Cooper.  W3C. 8 December 2021. W3C Candidate Recommendation. URL: <a href="https://www.w3.org/TR/wai-aria-1.2/">https://www.w3.org/TR/wai-aria-1.2/</a></dd></dl>
+  </section><section id="informative-references">
+    <h3 id="c-2-informative-references"><bdi class="secno">C.2 </bdi>Informative references<a class="self-link" href="#informative-references" aria-label="Permalink for Appendix C.2"></a></h3>
+    <dl class="bibliography"><dt id="bib-at-spi">[AT-SPI]</dt><dd><a href="https://developer.gnome.org/libatspi/stable/"><cite>Assistive Technology Service Provider Interface</cite></a>.  The GNOME Project. URL: <a href="https://developer.gnome.org/libatspi/stable/">https://developer.gnome.org/libatspi/stable/</a></dd><dt id="bib-atk">[ATK]</dt><dd><a href="https://developer.gnome.org/atk/stable/"><cite>ATK - Accessibility Toolkit</cite></a>.  The GNOME Project. URL: <a href="https://developer.gnome.org/atk/stable/">https://developer.gnome.org/atk/stable/</a></dd><dt id="bib-axapi">[AXAPI]</dt><dd><a href="https://developer.apple.com/documentation/appkit/nsaccessibility"><cite>The NSAccessibility Protocol for macOS</cite></a>.  Apple, Inc. URL: <a href="https://developer.apple.com/documentation/appkit/nsaccessibility">https://developer.apple.com/documentation/appkit/nsaccessibility</a></dd><dt id="bib-core-aam-1.1">[CORE-AAM-1.1]</dt><dd><a href="https://www.w3.org/TR/core-aam-1.1/"><cite>Core Accessibility API Mappings 1.1</cite></a>. Joanmarie Diggs; Joseph Scheuhammer; Richard Schwerdtfeger; Michael Cooper; Andi Snow-Weaver; Aaron Leventhal.  W3C. 14 December 2017. W3C Recommendation. URL: <a href="https://www.w3.org/TR/core-aam-1.1/">https://www.w3.org/TR/core-aam-1.1/</a></dd><dt id="bib-ui-automation">[UI-AUTOMATION]</dt><dd><a href="https://docs.microsoft.com/en-us/windows/win32/winauto/ui-automation-specification"><cite>UI Automation</cite></a>.  Microsoft Corporation. URL: <a href="https://docs.microsoft.com/en-us/windows/win32/winauto/ui-automation-specification">https://docs.microsoft.com/en-us/windows/win32/winauto/ui-automation-specification</a></dd><dt id="bib-wai-aria">[wai-aria]</dt><dd><a href="https://www.w3.org/TR/wai-aria/"><cite>Accessible Rich Internet Applications (WAI-ARIA) 1.0</cite></a>. James Craig; Michael Cooper et al.  W3C. 20 March 2014. W3C Recommendation. URL: <a href="https://www.w3.org/TR/wai-aria/">https://www.w3.org/TR/wai-aria/</a></dd><dt id="bib-wai-aria-practices-1.2">[WAI-ARIA-PRACTICES-1.2]</dt><dd><a href="https://www.w3.org/TR/wai-aria-practices-1.2/"><cite>WAI-ARIA Authoring Practices 1.2</cite></a>. Matthew King; JaEun Jemma Ku; James Nurthen; Zoë Bijl; Michael Cooper.  W3C. 29 November 2021. W3C Working Group Note. URL: <a href="https://www.w3.org/TR/wai-aria-practices-1.2/">https://www.w3.org/TR/wai-aria-practices-1.2/</a></dd><dt id="bib-wai-aria-roadmap">[WAI-ARIA-ROADMAP]</dt><dd><a href="https://www.w3.org/TR/wai-aria-roadmap/"><cite>Roadmap for Accessible Rich Internet Applications (WAI-ARIA Roadmap)</cite></a>. Richard Schwerdtfeger.  W3C. 4 February 2008. W3C Working Draft. URL: <a href="https://www.w3.org/TR/wai-aria-roadmap/">https://www.w3.org/TR/wai-aria-roadmap/</a></dd></dl>
+  </section></section><p role="navigation" id="back-to-top">
+    <a href="#title"><abbr title="Back to Top">↑</abbr></a>
+  </p><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-accessibility-subtree" aria-label="Links in this document to definition: Accessibility Subtree">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-accessibility-subtree" aria-label="Permalink for definition: Accessibility Subtree. Activate to close this dialog.">Permalink</a>
+        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+    <a href="#ref-for-dfn-accessibility-subtree-1" title="§ 4.8.2 Changes to document content or node visibility">§ 4.8.2 Changes to document content or node visibility</a> 
+  </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-accessibility-tree" aria-label="Links in this document to definition: Accessibility Tree">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-accessibility-tree" aria-label="Permalink for definition: Accessibility Tree. Activate to close this dialog.">Permalink</a>
+        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+    <a href="#ref-for-dfn-accessibility-tree-1" title="§ 1.2.3 Accessible Names and Descriptions">§ 1.2.3 Accessible Names and Descriptions</a> 
+  </li><li>
+    <a href="#ref-for-dfn-accessibility-tree-2" title="§ 3. Important Terms">§ 3. Important Terms</a> <a href="#ref-for-dfn-accessibility-tree-3" title="Reference 2">(2)</a> 
+  </li><li>
+    <a href="#ref-for-dfn-accessibility-tree-4" title="§ 4.1 General rules for exposing WAI-ARIA semantics">§ 4.1 General rules for exposing WAI-ARIA semantics</a> 
+  </li><li>
+    <a href="#ref-for-dfn-accessibility-tree-5" title="§ 4.4.2 Role Mapping Table">§ 4.4.2 Role Mapping Table</a> <a href="#ref-for-dfn-accessibility-tree-6" title="Reference 2">(2)</a> <a href="#ref-for-dfn-accessibility-tree-7" title="Reference 3">(3)</a> <a href="#ref-for-dfn-accessibility-tree-8" title="Reference 4">(4)</a> <a href="#ref-for-dfn-accessibility-tree-9" title="Reference 5">(5)</a> <a href="#ref-for-dfn-accessibility-tree-10" title="Reference 6">(6)</a> <a href="#ref-for-dfn-accessibility-tree-11" title="Reference 7">(7)</a> <a href="#ref-for-dfn-accessibility-tree-12" title="Reference 8">(8)</a> <a href="#ref-for-dfn-accessibility-tree-13" title="Reference 9">(9)</a> <a href="#ref-for-dfn-accessibility-tree-14" title="Reference 10">(10)</a> <a href="#ref-for-dfn-accessibility-tree-15" title="Reference 11">(11)</a> <a href="#ref-for-dfn-accessibility-tree-16" title="Reference 12">(12)</a> <a href="#ref-for-dfn-accessibility-tree-17" title="Reference 13">(13)</a> <a href="#ref-for-dfn-accessibility-tree-18" title="Reference 14">(14)</a> <a href="#ref-for-dfn-accessibility-tree-19" title="Reference 15">(15)</a> <a href="#ref-for-dfn-accessibility-tree-20" title="Reference 16">(16)</a> <a href="#ref-for-dfn-accessibility-tree-21" title="Reference 17">(17)</a> <a href="#ref-for-dfn-accessibility-tree-22" title="Reference 18">(18)</a> <a href="#ref-for-dfn-accessibility-tree-23" title="Reference 19">(19)</a> <a href="#ref-for-dfn-accessibility-tree-24" title="Reference 20">(20)</a> <a href="#ref-for-dfn-accessibility-tree-25" title="Reference 21">(21)</a> <a href="#ref-for-dfn-accessibility-tree-26" title="Reference 22">(22)</a> <a href="#ref-for-dfn-accessibility-tree-27" title="Reference 23">(23)</a> <a href="#ref-for-dfn-accessibility-tree-28" title="Reference 24">(24)</a> <a href="#ref-for-dfn-accessibility-tree-29" title="Reference 25">(25)</a> <a href="#ref-for-dfn-accessibility-tree-30" title="Reference 26">(26)</a> <a href="#ref-for-dfn-accessibility-tree-31" title="Reference 27">(27)</a> <a href="#ref-for-dfn-accessibility-tree-32" title="Reference 28">(28)</a> <a href="#ref-for-dfn-accessibility-tree-33" title="Reference 29">(29)</a> <a href="#ref-for-dfn-accessibility-tree-34" title="Reference 30">(30)</a> <a href="#ref-for-dfn-accessibility-tree-35" title="Reference 31">(31)</a> <a href="#ref-for-dfn-accessibility-tree-36" title="Reference 32">(32)</a> 
+  </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-activation-behavior" aria-label="Links in this document to definition: Activation behavior">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-activation-behavior" aria-label="Permalink for definition: Activation behavior. Activate to close this dialog.">Permalink</a>
+        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+      <li>Not referenced in this document.</li>
+    </ul>
+    </div><script id="respec-dfn-panel">(() => {
+// @ts-check
+if (document.respec) {
+  document.respec.ready.then(setupPanel);
+} else {
+  setupPanel();
+}
+
+function setupPanel() {
+  const listener = panelListener();
+  document.body.addEventListener("keydown", listener);
+  document.body.addEventListener("click", listener);
+}
+
+function panelListener() {
+  /** @type {HTMLElement} */
+  let panel = null;
+  return event => {
+    const { target, type } = event;
+
+    if (!(target instanceof HTMLElement)) return;
+
+    // For keys, we only care about Enter key to activate the panel
+    // otherwise it's activated via a click.
+    if (type === "keydown" && event.key !== "Enter") return;
+
+    const action = deriveAction(event);
+
+    switch (action) {
+      case "show": {
+        hidePanel(panel);
+        /** @type {HTMLElement} */
+        const dfn = target.closest("dfn, .index-term");
+        panel = document.getElementById(`dfn-panel-for-${dfn.id}`);
+        const coords = deriveCoordinates(event);
+        displayPanel(dfn, panel, coords);
+        break;
+      }
+      case "dock": {
+        panel.style.left = null;
+        panel.style.top = null;
+        panel.classList.add("docked");
+        break;
+      }
+      case "hide": {
+        hidePanel(panel);
+        panel = null;
+        break;
+      }
+    }
+  };
+}
+
+/**
+ * @param {MouseEvent|KeyboardEvent} event
+ */
+function deriveCoordinates(event) {
+  const target = /** @type HTMLElement */ (event.target);
+
+  // We prevent synthetic AT clicks from putting
+  // the dialog in a weird place. The AT events sometimes
+  // lack coordinates, so they have clientX/Y = 0
+  const rect = target.getBoundingClientRect();
+  if (
+    event instanceof MouseEvent &&
+    event.clientX >= rect.left &&
+    event.clientY >= rect.top
+  ) {
+    // The event probably happened inside the bounding rect...
+    return { x: event.clientX, y: event.clientY };
+  }
+
+  // Offset to the middle of the element
+  const x = rect.x + rect.width / 2;
+  // Placed at the bottom of the element
+  const y = rect.y + rect.height;
+  return { x, y };
+}
+
+/**
+ * @param {Event} event
+ */
+function deriveAction(event) {
+  const target = /** @type {HTMLElement} */ (event.target);
+  const hitALink = !!target.closest("a");
+  if (target.closest("dfn:not([data-cite]), .index-term")) {
+    return hitALink ? "none" : "show";
+  }
+  if (target.closest(".dfn-panel")) {
+    if (hitALink) {
+      return target.classList.contains("self-link") ? "hide" : "dock";
+    }
+    const panel = target.closest(".dfn-panel");
+    return panel.classList.contains("docked") ? "hide" : "none";
+  }
+  if (document.querySelector(".dfn-panel:not([hidden])")) {
+    return "hide";
+  }
+  return "none";
+}
+
+/**
+ * @param {HTMLElement} dfn
+ * @param {HTMLElement} panel
+ * @param {{ x: number, y: number }} clickPosition
+ */
+function displayPanel(dfn, panel, { x, y }) {
+  panel.hidden = false;
+  // distance (px) between edge of panel and the pointing triangle (caret)
+  const MARGIN = 20;
+
+  const dfnRects = dfn.getClientRects();
+  // Find the `top` offset when the `dfn` can be spread across multiple lines
+  let closestTop = 0;
+  let minDiff = Infinity;
+  for (const rect of dfnRects) {
+    const { top, bottom } = rect;
+    const diffFromClickY = Math.abs((top + bottom) / 2 - y);
+    if (diffFromClickY < minDiff) {
+      minDiff = diffFromClickY;
+      closestTop = top;
+    }
+  }
+
+  const top = window.scrollY + closestTop + dfnRects[0].height;
+  const left = x - MARGIN;
+  panel.style.left = `${left}px`;
+  panel.style.top = `${top}px`;
+
+  // Find if the panel is flowing out of the window
+  const panelRect = panel.getBoundingClientRect();
+  const SCREEN_WIDTH = Math.min(window.innerWidth, window.screen.width);
+  if (panelRect.right > SCREEN_WIDTH) {
+    const newLeft = Math.max(MARGIN, x + MARGIN - panelRect.width);
+    const newCaretOffset = left - newLeft;
+    panel.style.left = `${newLeft}px`;
+    /** @type {HTMLElement} */
+    const caret = panel.querySelector(".caret");
+    caret.style.left = `${newCaretOffset}px`;
+  }
+
+  // As it's a dialog, we trap focus.
+  // TODO: when <dialog> becomes a implemented, we should really
+  // use that.
+  trapFocus(panel, dfn);
+}
+
+/**
+ * @param {HTMLElement} panel
+ * @param {HTMLElement} dfn
+ * @returns
+ */
+function trapFocus(panel, dfn) {
+  /** @type NodeListOf<HTMLAnchorElement> elements */
+  const anchors = panel.querySelectorAll("a[href]");
+  // No need to trap focus
+  if (!anchors.length) return;
+
+  // Move focus to first anchor element
+  const first = anchors.item(0);
+  first.focus();
+
+  const trapListener = createTrapListener(anchors, panel, dfn);
+  panel.addEventListener("keydown", trapListener);
+
+  // Hiding the panel releases the trap
+  const mo = new MutationObserver(records => {
+    const [record] = records;
+    const target = /** @type HTMLElement */ (record.target);
+    if (target.hidden) {
+      panel.removeEventListener("keydown", trapListener);
+      mo.disconnect();
+    }
+  });
+  mo.observe(panel, { attributes: true, attributeFilter: ["hidden"] });
+}
+
+/**
+ *
+ * @param {NodeListOf<HTMLAnchorElement>} anchors
+ * @param {HTMLElement} panel
+ * @param {HTMLElement} dfn
+ * @returns
+ */
+function createTrapListener(anchors, panel, dfn) {
+  const lastIndex = anchors.length - 1;
+  let currentIndex = 0;
+  return event => {
+    switch (event.key) {
+      // Hitting "Tab" traps us in a nice loop around elements.
+      case "Tab": {
+        event.preventDefault();
+        currentIndex += event.shiftKey ? -1 : +1;
+        if (currentIndex < 0) {
+          currentIndex = lastIndex;
+        } else if (currentIndex > lastIndex) {
+          currentIndex = 0;
+        }
+        anchors.item(currentIndex).focus();
+        break;
+      }
+
+      // Hitting "Enter" on an anchor releases the trap.
+      case "Enter":
+        hidePanel(panel);
+        break;
+
+      // Hitting "Escape" returns focus to dfn.
+      case "Escape":
+        hidePanel(panel);
+        dfn.focus();
+        return;
+    }
+  };
+}
+
+/** @param {HTMLElement} panel */
+function hidePanel(panel) {
+  if (!panel) return;
+  panel.hidden = true;
+  panel.classList.remove("docked");
+}
+})()</script><script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script></body></html>


### PR DESCRIPTION
This is regard to: https://github.com/w3c/core-aam/issues/102

Questions:
- Do we want the "saved"/"exported" spec to use the summary details instead of the table? If so, automatic exporting of the spec will work now, with the summary details version of the tables. You can see this in the preview link below.
- I couldn't test whether this solves the gh-pages bug (where the IDs are missing currently here: https://w3c.github.io/core-aam/), because I could never replicate that bug locally. But @jnurthen thinks this might fix it :) If anyone had ideas about how to replicate that scenario (besides running respec from the CLI, like it looks like it does in the github action) I'd like to hear about it!
- I also removed the dependencies on respec events as in the issue it was discussed repub no longer publishes events. It turns out that the "mappingTables" function is called during respect "preprocessing" (as was configured in the `preProcess` parameter in the `respecConfig`), so once i removed the respec events code -- which was causing an error -- the tables showed up twice (as mappingTables was run twice, once during preprocessing and once when mapping-tables.js was loaded).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 15, 2022, 11:22 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fcore-aam%2Ff723f1f3fcc451d9bed02d85e752347291ade8be%2Findex.html%3FisPreview%3Dtrue)

```
📡 HTTP Error 429: https://rawcdn.githack.com/w3c/core-aam/f723f1f3fcc451d9bed02d85e752347291ade8be/index.html
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/core-aam%23105.)._
</details>
