### PR TITLE
Use default license

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,6 @@
     // if you wish the publication date to be other than today, set this
     //publishDate:  "2014-12-11",
     copyrightStart:  "2014",
-    license: "document",
 
     // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
     // and its maturity status


### PR DESCRIPTION
New charter has changed license to Respec default


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/pull/108.html" title="Last updated on Feb 9, 2022, 1:02 PM UTC (2499ebf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/108/8b6cc1c...2499ebf.html" title="Last updated on Feb 9, 2022, 1:02 PM UTC (2499ebf)">Diff</a>