### PR TITLE
Update AX API mapping for aria-describedby

### DIFF
--- a/index.html
+++ b/index.html
@@ -2653,7 +2653,8 @@ var mappingTableLabels = {
 					<span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a> and <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
 				</td>
 				<td class="attr-axapi">
-					<span class="property">Property: <code>AXHelp</code>: <code>&lt;value&gt;</code></span><br />
+					In macOS 11.0+, use <span class="property">Property: <code>AXCustomContent</code>: <code>&lt;value&gt;</code></span><br />
+					For earlier versions, use <span class="property">Property: <code>AXHelp</code>: <code>&lt;value&gt;</code></span><br />
 					<span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
 				</td>
 			</tr>


### PR DESCRIPTION
Resolves #104, adds newer AXCustomContent property available in macOS 11.0 and later


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/pull/114.html" title="Last updated on Apr 21, 2022, 8:13 PM UTC (c7728fc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/114/deec148...c7728fc.html" title="Last updated on Apr 21, 2022, 8:13 PM UTC (c7728fc)">Diff</a>