### PR TITLE
remove AXAPI-specific 'menuitem in group' guidance; 

### DIFF
--- a/index.html
+++ b/index.html
@@ -1305,7 +1305,7 @@ var mappingTableLabels = {
 					</td>
 				</tr>
 				<tr id="role-map-menuitem">
-					<th><a class="role-reference" href="#menuitem"><code>menuitem</code></a> not owned by or child of <code>group</code></th>
+					<th><a class="role-reference" href="#menuitem"><code>menuitem</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_MENUITEM</code></span>
 					</td>
@@ -1317,22 +1317,6 @@ var mappingTableLabels = {
 					</td>
 					<td class="role-axapi">
 						<span class="property">AXRole: <code>AXMenuItem</code></span><br />
-						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
-					</td>
-				</tr>
-				<tr id="role-map-menuitem-group-parent">
-					<th><a class="role-reference" href="#menuitem"><code>menuitem</code></a> owned by or child of <code>group</code></th>
-					<td class="role-msaa-ia2">
-						<span class="property">Role: <code>ROLE_SYSTEM_MENUITEM</code></span>
-					</td>
-					<td class="role-uia">
-						<span class="property">Control Type: <code>MenuItem</code></span>
-					</td>
-					<td class="role-atk">
-						<span class="property">Role: <code>ROLE_MENU_ITEM</code></span>
-					</td>
-					<td class="role-axapi">
-						<span class="property">AXRole: <code>AXMenuButton</code></span><br />
 						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
 					</td>
 				</tr>


### PR DESCRIPTION
menuitem should map to AXMenuItem in group and non-group contexts.

Resolves #78

* WPT tests: [link](https://github.com/web-platform-tests/wpt/pull/38310)
* Implementations (link to issue or when done, link to commit):
   * WebKit: n/a, always surfaced as AXMenuItem
   * Gecko: n/a, always surfaced as AXMenuItem
   * Blink: n/a, always surfaced as AXMenuItem


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/pull/132.html" title="Last updated on Feb 1, 2023, 10:22 PM UTC (b581732)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/132/1d4e8a5...b581732.html" title="Last updated on Feb 1, 2023, 10:22 PM UTC (b581732)">Diff</a>