### PR TITLE
remove reference to whitespace

### DIFF
--- a/index.html
+++ b/index.html
@@ -3667,7 +3667,7 @@ var mappingTableLabels = {
 				</td>
 			</tr>
 			<tr id="ariaRoleDescriptionEmptyString">
-				<th><a class="property-reference" href="#aria-roledescription"><code>aria-roledescription</code></a> is the empty string</th>
+				<th><a class="property-reference" href="#aria-roledescription"><code>aria-roledescription</code></a> is undefined or the empty string</th>
 				<td class="attr-msaa-ia2">
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
 				</td>

--- a/index.html
+++ b/index.html
@@ -3666,8 +3666,8 @@ var mappingTableLabels = {
 					<span class="property">Property: <code>AXRoleDescription</code>: <code>&lt;value&gt;</code></span>
 				</td>
 			</tr>
-			<tr id="ariaRoleDescriptionEmptyWhiteSpaceString">
-				<th><a class="property-reference" href="#aria-roledescription"><code>aria-roledescription</code></a> is empty or whitespace characters</th>
+			<tr id="ariaRoleDescriptionEmptyString">
+				<th><a class="property-reference" href="#aria-roledescription"><code>aria-roledescription</code></a> is the empty string</th>
 				<td class="attr-msaa-ia2">
 					<span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
 				</td>


### PR DESCRIPTION
resolves #128

Per https://www.w3.org/2022/08/11-aria-minutes#t05, the WG resolved that the empty string should cause the attribute to be ignored, but not whitespace.  So, reference to whitespace can be removed from this spec.  However, referring to whitespace will remain in the ARIA spec and THERE it will link to the ascii-whitespace definition where applicable.   Additionally, rather than a user agent requirement, it will become an authors requirement on not specifying whitespace as the value of an aria-roledescription


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/pull/135.html" title="Last updated on Aug 25, 2022, 7:34 PM UTC (fac0c9f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/135/1d4e8a5...fac0c9f.html" title="Last updated on Aug 25, 2022, 7:34 PM UTC (fac0c9f)">Diff</a>