### PR TITLE
Update annotation roles AXAPI mapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -736,6 +736,7 @@ var mappingTableLabels = {
 					<td class="role-axapi">
 						<span class="property">AXRole: <code>AXGroup</code></span><br />
 						<span class="property">AXSubrole: <code>AXDeleteStyleGroup</code></span><br />
+                                                <span class="property">AXAttributedStringForTextMarkerRange: contains <code>AXIsSuggestedDeletion = 1;</code> for all text contained in a <code>deletion</code></span>
 					</td>
 				</tr>
 				<tr id="role-map-dialog">
@@ -1018,6 +1019,7 @@ var mappingTableLabels = {
 					<td class="role-axapi">
 						<span class="property">AXRole: <code>AXGroup</code></span><br />
 						<span class="property">AXSubrole: <code>AXInsertStyleGroup</code></span><br />
+                                                <span class="property">AXAttributedStringForTextMarkerRange: contains <code>AXIsSuggestedInsertion = 1;</code> for all text contained in a <code>insertion</code></span>
 					</td>
 				</tr>
 				<tr id="role-map-label">
@@ -1218,10 +1220,12 @@ var mappingTableLabels = {
 					</td>
 					<td class="role-atk">
 						<span class="property">Role: <code>ROLE_MARK</code></span><br />
-            <span class="property">Object Attribute: <code>xml-roles:mark</code></span>
+                                                <span class="property">Object Attribute: <code>xml-roles:mark</code></span>
 					</td>
 					<td class="role-axapi">
-						<span class="property">AXRole: <code>AXGroup</code></span>
+						<span class="property">AXRole: <code>AXGroup</code></span><br />
+						<span class="property">AXRoleDescription: <code>highlight</code></span><br />
+                                                <span class="property">AXAttributedStringForTextMarkerRange: contains <code>AXHighlight = 1;</code> for all text contained in a <code>mark</code></span>
 					</td>
 				</tr>
 				<tr id="role-map-marquee">
@@ -1907,6 +1911,7 @@ var mappingTableLabels = {
 					</td>
 					<td class="role-axapi">
 						<span class="property">AXRole: <code>AXGroup</code></span><br />
+                                                <span class="property">AXAttributedStringForTextMarkerRange: contains <code>AXIsSuggestion = 1;</code> for all text contained in a <code>suggestion</code></span>
 					</td>
 				</tr>
 				<tr id="role-map-superscript">


### PR DESCRIPTION
Brought to my attention in: https://bugs.chromium.org/p/chromium/issues/detail?id=1359005

We have never documented `AXAttributedStringForTextMarkerRange` -- but it looks like it is typically used for surfacing CSS attributes.

* WPT tests: [PR](https://github.com/web-platform-tests/wpt/pull/39446)
* Implementations (link to issue or when done, link to commit):
   * WebKit: n/a, implemented
   * Gecko: [Issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1814511)
   * Blink: [landed](https://chromium-review.googlesource.com/c/chromium/src/+/3964928)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/pull/137.html" title="Last updated on Feb 1, 2023, 10:09 PM UTC (ebf92fb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/137/11e02ec...ebf92fb.html" title="Last updated on Feb 1, 2023, 10:09 PM UTC (ebf92fb)">Diff</a>