### PR TITLE
Update AXAPI mapping for aria-keyshortcuts

### DIFF
--- a/index.html
+++ b/index.html
@@ -3125,7 +3125,7 @@ var mappingTableLabels = {
 					<span class="property">Object Attribute: <code>keyshortcuts:&lt;value&gt;</code></span>
 				</td>
 				<td class="attr-axapi">
-					<span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+					<span class="property">Property: <code>AXKeyShortcutsValue</code>: <code>&lt;value&gt;</code></span>
 				</td>
 			</tr>
 			<tr id="ariaLabel">


### PR DESCRIPTION
Just noticed this said "not mapped" when, in fact, it is mapped.

* WPT tests: [PR](https://github.com/web-platform-tests/wpt/pull/36082)
* Implementations (link to issue or when done, link to commit):
   * WebKit: n/a, matches implementation
   * Gecko: [General issue for aria-keyshortcut support](https://bugzilla.mozilla.org/show_bug.cgi?id=1467382)
   * Blink: n/a, matches implementation


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/pull/140.html" title="Last updated on Feb 1, 2023, 9:53 PM UTC (e4d00de)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/140/fbad1bd...e4d00de.html" title="Last updated on Feb 1, 2023, 9:53 PM UTC (e4d00de)">Diff</a>