### PR TITLE
Update aria-describedby and aria-description AXAPI

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,7 +260,7 @@ var mappingTableLabels = {
         <p>For instance, in MSAA, all <a class="termref">accessible objects</a> support the <code>accName</code> property, which stores the object's <a class="termref" data-cite="accname-1.2#dfn-accessible-name">accessible name</a>. Where the object also supports having an <a class="termref" data-cite="accname-1.2#dfn-accessible-description">accessible description</a>, MSAA stores this property in the object's <code>accDescription</code> property.</p>
         <p>Software using ATK can read and write to an object's <code>accessible-name</code> and <code>accessible-description</code> properties. In turn, AT-SPI can query the values of those properties through its <code>atspi_accessible_get_name</code> and <code>atspi_accessible_get_description</code> functions.</p>
         <p>Automation elements in the UIA accessibility tree have a <code>Name</code> property. Where the object also supports having an <a class="termref" data-cite="accname-1.2#dfn-accessible-description">accessible description</a>, UIA stores this property in the object's <code>FullDescription</code> property.</p>
-        <p>The approach to <a class="termref" data-cite="accname-1.2#dfn-accessible-name">accessible names</a> and <a class="termref" data-lt="accessible description" data-cite="accname-1.2#dfn-accessible-description">accessible descriptions</a> in AX API is somewhat different to the other platform APIs. <a class="termref" data-cite="accname-1.2#dfn-accessible-name">Accessible names</a> are exposed using the <code>AXTitle</code> property when the name is visually rendered, while the <code>AXDescription</code> property is used when the object's name is not rendered visually. An object's <a class="termref" data-cite="accname-1.2#dfn-accessible-description">accessible description</a>, where provided, should always be exposed in the <code>AXHelp</code> property.</p>
+        <p>The approach to <a class="termref" data-cite="accname-1.2#dfn-accessible-name">accessible names</a> and <a class="termref" data-lt="accessible description" data-cite="accname-1.2#dfn-accessible-description">accessible descriptions</a> in AX API is somewhat different to the other platform APIs. <a class="termref" data-cite="accname-1.2#dfn-accessible-name">Accessible names</a> are exposed using the <code>AXTitle</code> property when the name is visually rendered, while the <code>AXDescription</code> property is used when the object's name is not rendered visually. An object's <a class="termref" data-cite="accname-1.2#dfn-accessible-description">accessible description</a>, where provided by <a class="state-reference" href="#aria-description"><code>aria-description</code></a> or <a class="state-reference" href="#aria-describedby"><code>aria-describedby</code></a>, should be exposed in the <code>accessibilityCustomContent</code> API. Otherwise, it should be exposed as <code>AXHelp</code>.</p>
         <p>For more detail, see the <a class="accname" href="">Accessible Name and Description Computation</a> specification.</p>
       </section>
     </section>
@@ -2653,8 +2653,8 @@ var mappingTableLabels = {
 					<span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a> and <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
 				</td>
 				<td class="attr-axapi">
-					<span class="property">Property: <code>AXHelp</code>: <code>&lt;value&gt;</code></span><br />
-					<span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+					<span class="api">In the accessibilityCustomContent API, expose as an <code>AXCustomContent</code> object with <code>{ label: "description" }</code> and `<code>value</code>` set to the description string.</span><br />
+-                                       <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
 				</td>
 			</tr>
 			<tr id="ariaDescription">
@@ -2672,8 +2672,8 @@ var mappingTableLabels = {
 					<span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
 				</td>
 				<td class="attr-axapi">
-					<span class="property">Property: <code>AXHelp</code>: <code>&lt;value&gt;</code></span><br />
-					<span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+					<span class="api">In the accessibilityCustomContent API, expose as an <code>AXCustomContent</code> object with <code>{ label: "description" }</code> and `<code>value</code>` set to the description string.</span><br />
+                                        <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
 				</td>
 			</tr>
 			<tr id="ariaDetails">


### PR DESCRIPTION
Webkit exposes `aria-description` in AXCustomContent.

In an email thread with @cookiecrook , I asked if `aria-describedby` should also be surfaced in AXCustomContent as well and he said "sounds like a good idea". So will webkit expose aria-describedby in AXCustomContent, should we make this change here then?

* WPT tests: [PR](https://github.com/web-platform-tests/wpt/pull/38307)
* Implementations (link to issue or when done, link to commit):
   * WebKit: [aria-description landed](https://bugs.webkit.org/show_bug.cgi?id=206253), [aria-describedby issue](https://bugs.webkit.org/show_bug.cgi?id=245985)
   * Gecko: [issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1814504)
   * Blink: [aria-description landed](https://chromium-review.googlesource.com/c/chromium/src/+/4015695), [aria-describedby landed](https://chromium-review.googlesource.com/c/chromium/src/+/4209251)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/pull/142.html" title="Last updated on Feb 1, 2023, 9:44 PM UTC (8ace8f4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/142/fbad1bd...8ace8f4.html" title="Last updated on Feb 1, 2023, 9:44 PM UTC (8ace8f4)">Diff</a>