### PR TITLE
Update role='meter' subrole for AXAPI

### DIFF
--- a/index.html
+++ b/index.html
@@ -1352,7 +1352,7 @@ var mappingTableLabels = {
 					</td>
 					<td class="role-axapi">
 						<span class="property">AXRole: <code>AXLevelIndicator</code></span><br />
-						<span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br />
+						<span class="property">AXSubrole: <code>AXMeter</code></span><br />
 					</td>
 				</tr>
 


### PR DESCRIPTION
Already closed, but this issue: https://github.com/w3c/core-aam/issues/42

Noticed that the patch that landed in webkit did leave the AXSubrole=AXMeter:  https://bugs.webkit.org/show_bug.cgi?id=164051

# Implementation


* WPT tests: [LINK](https://github.com/web-platform-tests/wpt/pull/39421)
* Implementations (link to issue or when done, link to commit):
   * WebKit: [PATCH](https://bugs.webkit.org/show_bug.cgi?id=164051)
   * Gecko: [ISSUE](https://bugzilla.mozilla.org/show_bug.cgi?id=1826904)
   * Blink: [ISSUE](https://bugs.chromium.org/p/chromium/issues/detail?id=1431341)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/pull/157.html" title="Last updated on Apr 6, 2023, 10:53 PM UTC (5ca2b95)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/157/21c8fbc...5ca2b95.html" title="Last updated on Apr 6, 2023, 10:53 PM UTC (5ca2b95)">Diff</a>