### PR TITLE
Update IA2 role='blockquote' map

### DIFF
--- a/index.html
+++ b/index.html
@@ -457,7 +457,7 @@ var mappingTableLabels = {
 					<th><a class="role-reference" href="#blockquote"><code>blockquote</code></a></th>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br />
-						<span class="property">Role: <code>IA2_ROLE_SECTION</code></span>
+						<span class="property">Role: <code>IA2_ROLE_BLOCK_QUOTE</code></span>
 					</td>
 					<td class="role-uia">
 						<span class="property">Control Type: <code>Group</code></span><br />


### PR DESCRIPTION
blockquote should map to IA2 role `IA2_ROLE_BLOCK_QUOTE`
see NVDA support: https://github.com/nvaccess/nvda/pull/8577

# Implementation

* WPT tests: [PR](https://github.com/web-platform-tests/wpt/pull/38303)
* Implementations (link to issue or when done, link to commit):
   * WebKit: n/a
   * Gecko: done
   * Blink: [Issue](https://bugs.chromium.org/p/chromium/issues/detail?id=1412169)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/pull/160.html" title="Last updated on Feb 1, 2023, 7:57 PM UTC (2588a37)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/160/21c8fbc...2588a37.html" title="Last updated on Feb 1, 2023, 7:57 PM UTC (2588a37)">Diff</a>