### PR TITLE
Update MSAA mapping for paragraph and time and caption

### DIFF
--- a/index.html
+++ b/index.html
@@ -2068,7 +2068,7 @@ var mappingTableLabels = {
 				<tr id="role-map-time">
 					<th><a class="role-reference" href="#time"><code>time</code></a></th>
 					<td class="role-msaa-ia2">
-						<span class="property">Role: <code>ROLE_SYSTEM_TEXT</code></span><br />
+						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br />
 						<span class="property">Object Attribute: <code>xml-roles:time</code></span>
 					</td>
 					<td class="role-uia">

--- a/index.html
+++ b/index.html
@@ -523,7 +523,7 @@ var mappingTableLabels = {
 				<tr id="role-map-caption">
 					<th><a class="role-reference" href="#caption"><code>caption</code></a></th>
 					<td class="role-msaa-ia2">
-						<span class="property">Role: <code>ROLE_SYSTEM_TEXT</code></span><br />
+						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br />
 						<span class="property">Role: <code>IA2_ROLE_CAPTION</code></span>
 					</td>
 					<td class="role-uia">

--- a/index.html
+++ b/index.html
@@ -1453,7 +1453,7 @@ var mappingTableLabels = {
 				<tr id="role-map-paragraph">
 					<th><a class="role-reference" href="#paragraph"><code>paragraph</code></a></th>
 					<td class="role-msaa-ia2">
-						<span class="property">Role: <code>ROLE_SYSTEM_TEXT</code></span><br />
+						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br />
 						<span class="property">Role: <code>IA2_ROLE_PARAGRAPH</code></span>
 					</td>
 					<td class="role-uia">
@@ -2068,7 +2068,7 @@ var mappingTableLabels = {
 				<tr id="role-map-time">
 					<th><a class="role-reference" href="#time"><code>time</code></a></th>
 					<td class="role-msaa-ia2">
-						<span class="property">Role: <code>ROLE_SYSTEM_STATICTEXT</code></span><br />
+						<span class="property">Role: <code>ROLE_SYSTEM_TEXT</code></span><br />
 						<span class="property">Object Attribute: <code>xml-roles:time</code></span>
 					</td>
 					<td class="role-uia">


### PR DESCRIPTION
The following issues where opened in chrome for the existing spec, and closed as wontfix, so this PR updates the spec to match chrome's implementation for MSAA for paragraph and time
* [paragraph](https://bugs.chromium.org/p/chromium/issues/detail?id=1406242#c3)
* [time](https://bugs.chromium.org/p/chromium/issues/detail?id=1406243#c3)

An issue was opened in firefox to match the `caption` role to the spec, and was also contested, so this change updates caption's MSAA mapping to be `ROLE_SYSTEM_GROUPING` per @jcsteh request.
* [caption](https://bugzilla.mozilla.org/show_bug.cgi?id=1809473)

# Implementation

* WPT tests: [PR](https://github.com/web-platform-tests/wpt/pull/38302)
* Implementations (link to issue or when done, link to commit):
   * WebKit: n/a
   * Gecko: [ISSUE for paragraph](https://bugzilla.mozilla.org/show_bug.cgi?id=1809475), [ISSUE for time](https://bugzilla.mozilla.org/show_bug.cgi?id=1732306)
   * Blink: current implementation for paragraph, [ISSUE for caption and time](https://bugs.chromium.org/p/chromium/issues/detail?id=1406530)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/pull/161.html" title="Last updated on Feb 1, 2023, 7:42 PM UTC (9a25c45)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/161/21c8fbc...9a25c45.html" title="Last updated on Feb 1, 2023, 7:42 PM UTC (9a25c45)">Diff</a>