### PR TITLE
Add computed role section and mappings

### DIFF
--- a/index.html
+++ b/index.html
@@ -345,7 +345,7 @@ var mappingTableLabels = {
     </section>
 		<section id="roleMappingComputedRole">
 		  <h2>Computed Role</h2>
-                  <p>The computed role of an element is a string that represents the role of the element for the purposes of specification comformance testing. When an element has a role but is not contained in the required context (for example, an role `listitem` outside of a `list`), the computed role of the element is unspecified.</p>
+                  <p>The computed role of an element is a string that represents the role of the element for the purposes of specification comformance testing. When an element has a role but is not contained in the required context (for example, a role `listitem` used on an element outside of a `list`), the computed role of the element is unspecified.</p>
                   <p class="note">User agents can provide this role string, for example, in response to the WebDriver function <a href="https://w3c.github.io/webdriver/#get-computed-role">`getComputedRole`</a>.</p>
     </section>
     <section id="mapping_role_table">

--- a/index.html
+++ b/index.html
@@ -345,7 +345,7 @@ var mappingTableLabels = {
     </section>
 		<section id="roleMappingComputedRole">
 		  <h2>Computed Role</h2>
-                  <p>The computed role of an element is a string that represents the role of the element for the purposes of specification comformance testing.</p>
+                  <p>The computed role of an element is a string that represents the role of the element for the purposes of specification comformance testing. When an element has a role but is not contained in the required context (for example, an role `listitem` outside of a `list`), the computed role of the element is unspecified.</p>
                   <p class="note">User agents can provide this role string, for example, in response to the WebDriver function <a href="https://w3c.github.io/webdriver/#get-computed-role">`getComputedRole`</a>.</p>
     </section>
     <section id="mapping_role_table">

--- a/index.html
+++ b/index.html
@@ -345,7 +345,7 @@ var mappingTableLabels = {
     </section>
 		<section id="roleMappingComputedRole">
 		  <h2>Computed Role</h2>
-                  The computed role of an element is a string that represents the role of the element for the purposes of specification comformance testing. User agents MUST provide this role string, for example, in response to the WebDriver function <a href="https://w3c.github.io/webdriver/#get-computed-role">`getComputedRole`</a>. In the role mapping table below, the computed role of the element will be provided for elements for which the computed role string is different than the role itsself.
+                  The computed role of an element is a string that represents the role of the element for the purposes of specification comformance testing. User agents MUST provide this role string, for example, in response to the WebDriver function <a href="https://w3c.github.io/webdriver/#get-computed-role">`getComputedRole`</a>. In the role mapping table below, the computed role of the element will be provided for elements for which the computed role string is different than the role itself.
     </section>
     <section id="mapping_role_table">
 		<h3>Role Mapping Table</h3>

--- a/index.html
+++ b/index.html
@@ -345,7 +345,8 @@ var mappingTableLabels = {
     </section>
 		<section id="roleMappingComputedRole">
 		  <h2>Computed Role</h2>
-                  The computed role of an element is a string that represents the role of the element for the purposes of specification comformance testing. User agents MUST provide this role string, for example, in response to the WebDriver function <a href="https://w3c.github.io/webdriver/#get-computed-role">`getComputedRole`</a>. In the role mapping table below, the computed role of the element will be provided for elements for which the computed role string is different than the role itself.
+                  <p>The computed role of an element is a string that represents the role of the element for the purposes of specification comformance testing.</p>
+                  <p class="note">User agents can provide this role string, for example, in response to the WebDriver function <a href="https://w3c.github.io/webdriver/#get-computed-role">`getComputedRole`</a>.</p>
     </section>
     <section id="mapping_role_table">
 		<h3>Role Mapping Table</h3>

--- a/index.html
+++ b/index.html
@@ -343,6 +343,10 @@ var mappingTableLabels = {
 			<li><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>: expose as an object attribute pair (<code>xml-roles:&quot;string&quot;</code>)</li>
 		  </ul>
     </section>
+		<section id="roleMappingComputedRole">
+		  <h2>Computed Role</h2>
+                  The computed role of an element is a string that represents the role of the element for the purposes of specification comformance testing. User agents MUST provide this role string, for example, in response to the WebDriver function <a href="https://w3c.github.io/webdriver/#get-computed-role">`getComputedRole`</a>. In the role mapping table below, the computed role of the element will be provided for elements for which the computed role string is different than the role itsself.
+    </section>
     <section id="mapping_role_table">
 		<h3>Role Mapping Table</h3>
       <p class="note">Translators: For label text associated with the following table and its toggle buttons, see the <code>mappingTableLabels</code> object in the <code>&lt;head&gt;</code> section of this document.</p>
@@ -352,6 +356,7 @@ var mappingTableLabels = {
 			<thead>
 				<tr>
 					<th><abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Role</th>
+					<th>Computed Role</th>
 					<th>MSAA + IAccessible2</th>
 					<th><abbr title="User Interface Automation">UIA</abbr></th>
 					<th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
@@ -361,6 +366,9 @@ var mappingTableLabels = {
 			<tbody>
 				<tr id="role-map-alert">
 					<th><a class="role-reference" href="#alert"><code>alert</code></a></th>
+					<td class="role-computed">
+						<p><code>alert</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_ALERT</code></span><br />
 						<span class="event">Event: The user agent SHOULD fire <code>EVENT_SYSTEM_ALERT</code>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span>
@@ -383,6 +391,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-alertdialog">
 					<th><a class="role-reference" href="#alertdialog"><code>alertdialog</code></a></th>
+					<td class="role-computed">
+						<p><code>alertdialog</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_DIALOG</code></span><br />
 						<span class="event">Event: The user agent SHOULD fire <code>EVENT_SYSTEM_ALERT</code>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span>
@@ -404,6 +415,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-application">
 					<th><a class="role-reference" href="#application"><code>application</code></a></th>
+					<td class="role-computed">
+						<p><code>application</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_APPLICATION</code></span>
 					</td>
@@ -421,6 +435,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-article">
 					<th><a class="role-reference" href="#article"><code>article</code></a></th>
+					<td class="role-computed">
+						<p><code>article</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_DOCUMENT</code></span><br />
 						<span class="property">State: <code>STATE_SYSTEM_READONLY</code></span><br />
@@ -441,6 +458,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-banner">
 					<th><a class="role-reference" href="#banner"><code>banner</code></a></th>
+					<td class="role-computed">
+						<p><code>banner</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br />
 						<span class="property">Object Attribute: <code>xml-roles:banner</code></span>
@@ -462,6 +482,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-blockquote">
 					<th><a class="role-reference" href="#blockquote"><code>blockquote</code></a></th>
+					<td class="role-computed">
+						<p><code>blockquote</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br />
 						<span class="property">Role: <code>IA2_ROLE_BLOCK_QUOTE</code></span>
@@ -480,6 +503,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-button">
 					<th><a class="role-reference" href="#button"><code>button</code></a> with default values for <a class="property-reference" href="#aria-pressed"><code>aria-pressed</code></a> and <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a></th>
+					<td class="role-computed">
+						<p><code>button</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_PUSHBUTTON</code></span>
 					</td>
@@ -496,6 +522,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-button-haspopup">
 					<th><a class="role-reference" href="#button"><code>button</code></a> with non-<code>false</code> value for <code>aria-haspopup</code></th>
+					<td class="role-computed">
+						<p><code>button</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_BUTTONMENU</code></span>
 					</td>
@@ -512,6 +541,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-button-pressed">
 					<th><a class="role-reference" href="#button"><code>button</code></a> with defined value for <a class="property-reference" href="#aria-pressed"><code>aria-pressed</code></a></th>
+					<td class="role-computed">
+						<p><code>button</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_PUSHBUTTON</code></span><br />
 						<span class="property">Role: <code>IA2_ROLE_TOGGLE_BUTTON</code></span>
@@ -529,6 +561,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-caption">
 					<th><a class="role-reference" href="#caption"><code>caption</code></a></th>
+					<td class="role-computed">
+						<p><code>caption</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br />
 						<span class="property">Role: <code>IA2_ROLE_CAPTION</code></span>
@@ -546,6 +581,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-cell">
 					<th><a class="role-reference" href="#cell"><code>cell</code></a></th>
+					<td class="role-computed">
+						<p><code>cell</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_CELL</code></span><br />
 						<span class="property">Interface: <code>IAccessibleTableCell</code></span>
@@ -567,6 +605,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-checkbox">
 					<th><a class="role-reference" href="#checkbox"><code>checkbox</code></a></th>
+					<td class="role-computed">
+						<p><code>checkbox</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_CHECKBUTTON</code></span><br />
 						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
@@ -587,6 +628,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-code">
 					<th><a class="role-reference" href="#code"><code>code</code></a></th>
+					<td class="role-computed">
+						<p><code>code</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span><br />
 						<span class="property">Object Attribute: <code>xml-roles:code</code></span>
@@ -606,6 +650,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-columnheader">
 					<th><a class="role-reference" href="#columnheader"><code>columnheader</code></a></th>
+					<td class="role-computed">
+						<p><code>columnheader</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_COLUMNHEADER</code></span><br />
 						<span class="property">Interface: <code>IAccessibleTableCell</code></span>
@@ -627,6 +674,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-combobox">
 					<th><a class="role-reference" href="#combobox"><code>combobox</code></a></th>
+					<td class="role-computed">
+						<p><code>combobox</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_COMBOBOX</code></span><br />
 						<span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span><br />
@@ -647,6 +697,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-comment">
 					<th><a class="role-reference" href="#comment"><code>comment</code></a></th>
+					<td class="role-computed">
+						<p><code>comment</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_COMMENT</code></span><br />
 						<span class="property">Object Attribute: <code>xml-roles:comment</code></span>
@@ -665,6 +718,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-complementary">
 					<th><a class="role-reference" href="#complementary"><code>complementary</code></a></th>
+					<td class="role-computed">
+						<p><code>complementary</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br />
 						<span class="property">Object Attribute: <code>xml-roles:complementary</code></span>
@@ -686,6 +742,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-contentinfo">
 					<th><a class="role-reference" href="#contentinfo"><code>contentinfo</code></a></th>
+					<td class="role-computed">
+						<p><code>contentinfo</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br />
 						<span class="property">Object Attribute: <code>xml-roles:contentinfo</code></span>
@@ -707,6 +766,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-definition">
 					<th><a class="role-reference" href="#definition"><code>definition</code></a></th>
+					<td class="role-computed">
+						<p><code>definition</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Object Attribute: <code>xml-roles:definition</code></span>
 					</td>
@@ -725,6 +787,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-deletion">
 					<th><a class="role-reference" href="#deletion"><code>deletion</code></a></th>
+					<td class="role-computed">
+						<p><code>deletion</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_CONTENT_DELETION</code></span>
 					</td>
@@ -744,6 +809,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-dialog">
 					<th><a class="role-reference" href="#dialog"><code>dialog</code></a></th>
+					<td class="role-computed">
+						<p><code>dialog</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_DIALOG</code></span>
 					</td>
@@ -761,6 +829,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-directory">
 					<th><a class="role-reference" href="#directory"><code>directory</code></a></th>
+					<td class="role-computed">
+						<p>list</p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_LIST</code></span>
 					</td>
@@ -777,6 +848,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-document">
 					<th><a class="role-reference" href="#document"><code>document</code></a></th>
+					<td class="role-computed">
+						<p><code>document</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_DOCUMENT</code></span><br />
 						<span class="property">State: <code>STATE_SYSTEM_READONLY</code></span>
@@ -794,6 +868,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-emphasis">
 					<th><a class="role-reference" href="#emphasis"><code>emphasis</code></a></th>
+					<td class="role-computed">
+						<p><code>emphasis</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span><br />
 						<span class="property">Object Attribute: <code>xml-roles:emphasis</code></span>
@@ -813,6 +890,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-feed">
 					<th><a class="role-reference" href="#feed"><code>feed</code></a></th>
+					<td class="role-computed">
+						<p><code>feed</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br />
 						<span class="property">Object Attribute: <code>xml-roles:feed</code></span>
@@ -832,6 +912,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-figure">
 					<th><a class="role-reference" href="#figure"><code>figure</code></a></th>
+					<td class="role-computed">
+						<p><code>figure</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br />
 						<span class="property">Object Attribute: <code>xml-roles:figure</code></span>
@@ -851,6 +934,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-form">
 					<th><a class="role-reference" href="#form"><code>form</code></a> with an accessible name</th>
+					<td class="role-computed">
+						<p><code>form</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_FORM</code></span><br />
 						<span class="property">Object Attribute: <code>xml-roles:form</code></span>
@@ -871,6 +957,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-form-nameless">
 					<th><a class="role-reference" href="#form"><code>form</code></a> without an accessible name</th>
+					<td class="role-computed">
+						<p><code>form</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
 					</td>
@@ -886,6 +975,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-generic">
 					<th><a class="role-reference" href="#generic"><code>generic</code></a></th>
+					<td class="role-computed">
+						<p><code>generic</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br />
 						<span class="property">Role: <code>IA2_ROLE_SECTION</code></span>
@@ -903,6 +995,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-grid">
 					<th><a class="role-reference" href="#grid"><code>grid</code></a></th>
+					<td class="role-computed">
+						<p><code>grid</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_TABLE</code></span><br />
 						<span class="property">Object Attribute: <code>xml-roles:grid</code></span><br />
@@ -933,6 +1028,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-gridcell">
 					<th><a class="role-reference" href="#gridcell"><code>gridcell</code></a></th>
+					<td class="role-computed">
+						<p><code>gridcell</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_CELL</code></span><br />
 						<span class="property">Interface: <code>IAccessibleTableCell</code></span>
@@ -956,6 +1054,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-group">
 					<th><a class="role-reference" href="#group"><code>group</code></a></th>
+					<td class="role-computed">
+						<p><code>group</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span>
 					</td>
@@ -972,6 +1073,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-heading">
 					<th><a class="role-reference" href="#heading"><code>heading</code></a></th>
+					<td class="role-computed">
+						<p><code>heading</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_HEADING</code></span><br />
 						<span class="property">Object Attribute: <code>xml-roles:heading</code></span>
@@ -990,6 +1094,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-img">
 					<th><a class="role-reference" href="#img"><code>img</code></a></th>
+					<td class="role-computed">
+						<p><code>image</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_GRAPHIC</code></span><br />
 						<span class="property">Interface: <code>IAccessibleImage</code></span>
@@ -1008,6 +1115,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-insertion">
 					<th><a class="role-reference" href="#insertion"><code>insertion</code></a></th>
+					<td class="role-computed">
+						<p><code>insertion</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_CONTENT_INSERTION</code></span>
 					</td>
@@ -1027,6 +1137,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-link">
 					<th><a class="role-reference" href="#link"><code>link</code></a></th>
+					<td class="role-computed">
+						<p><code>link</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_LINK</code></span><br />
 						<span class="property">State: <code>STATE_SYSTEM_LINKED</code></span><br />
@@ -1048,6 +1161,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-list">
 					<th><a class="role-reference" href="#list"><code>list</code></a></th>
+					<td class="role-computed">
+						<p><code>list</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_LIST</code></span><br />
 						<span class="property">State: <code>STATE_SYSTEM_READONLY</code></span>
@@ -1065,6 +1181,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-listbox">
 					<th><a class="role-reference" href="#listbox"><code>listbox</code></a> not owned by or child of <code>combobox</code></th>
+					<td class="role-computed">
+						<p><code>listbox</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_LIST</code></span><br />
 						<span class="method">Method: <code>IAccessible::accSelect()</code></span><br />
@@ -1086,6 +1205,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-listbox-in-combobox">
 					<th><a class="role-reference" href="#listbox"><code>listbox</code></a> owned by or child of <code>combobox</code></th>
+					<td class="role-computed">
+						<p><code>listbox</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_LIST</code></span><br />
 						<span class="method">Method: <code>IAccessible::accSelect()</code></span><br />
@@ -1107,6 +1229,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-listitem">
 					<th><a class="role-reference" href="#listitem"><code>listitem</code></a></th>
+					<td class="role-computed">
+						<p><code>listitem</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_LISTITEM</code></span><br />
 						<span class="property">State: <code>STATE_SYSTEM_READONLY</code></span>
@@ -1126,6 +1251,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-log">
 					<th><a class="role-reference" href="#log"><code>log</code></a></th>
+					<td class="role-computed">
+						<p><code>log</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Object Attribute: <code>xml-roles:log</code></span><br />
 						<span class="property">Object Attribute: <code>container-live:polite</code></span><br />
@@ -1151,6 +1279,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-main">
 					<th><a class="role-reference" href="#main"><code>main</code></a></th>
+					<td class="role-computed">
+						<p><code>main</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br />
 						<span class="property">Object Attribute: <code>xml-roles:main</code></span>
@@ -1171,6 +1302,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-mark">
 					<th><a class="role-reference" href="#mark"><code>mark</code></a></th>
+					<td class="role-computed">
+						<p><code>mark</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br />
 						<span class="property">Role: <code>IA2_ROLE_MARK</code></span><br />
@@ -1191,6 +1325,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-marquee">
 					<th><a class="role-reference" href="#marquee"><code>marquee</code></a></th>
+					<td class="role-computed">
+						<p><code>marquee</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_ANIMATION</code></span><br />
 						<span class="property">Object Attribute: <code>xml-roles:marquee</code></span><br />
@@ -1214,6 +1351,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-math">
 					<th><a class="role-reference" href="#math"><code>math</code></a></th>
+					<td class="role-computed">
+						<p><code>math</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_EQUATION</code></span>
 					</td>
@@ -1231,6 +1371,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-menu">
 					<th><a class="role-reference" href="#menu"><code>menu</code></a></th>
+					<td class="role-computed">
+						<p><code>menu</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_MENUPOPUP</code></span><br />
 						<span class="method">Method: <code>IAccessible::accSelect()</code></span><br />
@@ -1251,6 +1394,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-menubar">
 					<th><a class="role-reference" href="#menubar"><code>menubar</code></a></th>
+					<td class="role-computed">
+						<p><code>menubar</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_MENUBAR</code></span><br />
 						<span class="method">Method: <code>IAccessible::accSelect()</code></span><br />
@@ -1271,6 +1417,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-menuitem">
 					<th><a class="role-reference" href="#menuitem"><code>menuitem</code></a></th>
+					<td class="role-computed">
+						<p><code>menuitem</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_MENUITEM</code></span>
 					</td>
@@ -1287,6 +1436,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-menuitemcheckbox">
 					<th><a class="role-reference" href="#menuitemcheckbox"><code>menuitemcheckbox</code></a></th>
+					<td class="role-computed">
+						<p><code>menuitemcheckbox</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_CHECKBUTTON</code> or <code>ROLE_SYSTEM_MENUITEM</code></span><br />
 						<span class="property">Role: <code>IA2_ROLE_CHECK_MENU_ITEM</code></span><br />
@@ -1309,6 +1461,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-menuitemradio">
 					<th><a class="role-reference" href="#menuitemradio"><code>menuitemradio</code></a></th>
+					<td class="role-computed">
+						<p><code>menuitemradio</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_RADIOBUTTON</code> or <code>ROLE_SYSTEM_MENUITEM</code></span><br />
 						<span class="property">Role: <code>IA2_ROLE_RADIO_MENU_ITEM</code></span><br />
@@ -1332,6 +1487,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-meter">
 					<th><a class="role-reference" href="#meter"><code>meter</code></a></th>
+					<td class="role-computed">
+						<p><code>meter</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_LEVEL_BAR</code></span><br />
 						<span class="property">Interface: <code>IAcesssibleValue</code></span>
@@ -1353,6 +1511,9 @@ var mappingTableLabels = {
 
 				<tr id="role-map-navigation">
 					<th><a class="role-reference" href="#navigation"><code>navigation</code></a></th>
+					<td class="role-computed">
+						<p><code>navigation</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br />
 						<span class="property">Object Attribute: <code>xml-roles:navigation</code></span>
@@ -1373,6 +1534,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-none">
 				<th><a class="role-reference" href="#none"><code>none</code></a></th>
+					<td class="role-computed">
+						<p><code>none</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<p>For objects that have required owned descendants (e.g., a grid owns gridcells, a list owns listitems), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>IA2_ROLE_TEXT_FRAME</code>.  [=user agents=]  SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
 					</td>
@@ -1388,6 +1552,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-note">
 					<th><a class="role-reference" href="#note"><code>note</code></a></th>
+					<td class="role-computed">
+						<p><code>note</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_NOTE</code></span>
 					</td>
@@ -1405,6 +1572,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-option">
 					<th><a class="role-reference" href="#option"><code>option</code></a> not inside <code>combobox</code></th>
+					<td class="role-computed">
+						<p><code>option</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_LISTITEM</code></span><br />
 						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
@@ -1426,6 +1596,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-option-in-combobox">
 					<th><a class="role-reference" href="#option"><code>option</code></a> inside <code>combobox</code></th>
+					<td class="role-computed">
+						<p><code>option</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_LISTITEM</code></span><br />
 						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
@@ -1447,6 +1620,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-paragraph">
 					<th><a class="role-reference" href="#paragraph"><code>paragraph</code></a></th>
+					<td class="role-computed">
+						<p><code>paragraph</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br />
 						<span class="property">Role: <code>IA2_ROLE_PARAGRAPH</code></span>
@@ -1464,6 +1640,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-presentation">
 					<th><a class="role-reference" href="#presentation"><code>presentation</code></a></th>
+					<td class="role-computed">
+						<p><code>none</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<p>For objects that have required owned descendants (e.g., a grid owns gridcells, a list owns listitems), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>IA2_ROLE_TEXT_FRAME</code>.  [=user agents=]  SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
 					</td>
@@ -1479,6 +1658,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-progressbar">
 					<th><a class="role-reference" href="#progressbar"><code>progressbar</code></a></th>
+					<td class="role-computed">
+						<p><code>progressbar</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_PROGRESSBAR</code></span><br />
 						<span class="property">State: <code>STATE_SYSTEM_READONLY</code></span><br />
@@ -1500,6 +1682,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-radio">
 					<th><a class="role-reference" href="#radio"><code>radio</code></a></th>
+					<td class="role-computed">
+						<p><code>radio</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_RADIOBUTTON</code></span><br />
 						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>
@@ -1522,6 +1707,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-radiogroup">
 					<th><a class="role-reference" href="#radiogroup"><code>radiogroup</code></a></th>
+					<td class="role-computed">
+						<p><code>ragiogroup</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span>
 					</td>
@@ -1538,6 +1726,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-region">
 					<th><a class="role-reference" href="#region"><code>region</code></a> with an accessible name</th>
+					<td class="role-computed">
+						<p><code>region</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br />
 						<span class="property">Object Attribute: <code>xml-roles:region</code></span>
@@ -1559,6 +1750,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-region-nameless">
 					<th><a class="role-reference" href="#region"><code>region</code></a> without an accessible name</th>
+					<td class="role-computed">
+						<p>Use native host language role.</p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
 					</td>
@@ -1574,6 +1768,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-row">
 					<th><a class="role-reference" href="#row"><code>row</code></a> not inside <code>treegrid</code></th>
+					<td class="role-computed">
+						<p><code>row</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_ROW</code></span>
 					</td>
@@ -1592,6 +1789,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-row-in-treegrid">
 					<th><a class="role-reference" href="#row"><code>row</code></a> inside <code>treegrid</code></th>
+					<td class="role-computed">
+						<p><code>treegrid</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_OUTLINEITEM</code></span>
 					</td>
@@ -1610,6 +1810,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-rowgroup">
 					<th><a class="role-reference" href="#rowgroup"><code>rowgroup</code></a></th>
+					<td class="role-computed">
+						<p><code>rowgroup</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span>
 					</td>
@@ -1625,6 +1828,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-rowheader">
 					<th><a class="role-reference" href="#rowheader"><code>rowheader</code></a></th>
+					<td class="role-computed">
+						<p><code>rowheader</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_ROWHEADER</code></span><br />
 						<span class="property">Interface: <code>IAccessibleTableCell</code></span>
@@ -1644,6 +1850,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-scrollbar">
 					<th><a class="role-reference" href="#scrollbar"><code>scrollbar</code></a></th>
+					<td class="role-computed">
+						<p><code>scrollbar</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_SCROLLBAR</code></span><br />
 						<span class="property">Interface: <code>IAcesssibleValue</code></span>
@@ -1664,6 +1873,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-search">
 					<th><a class="role-reference" href="#search"><code>search</code></a></th>
+					<td class="role-computed">
+						<p><code>search</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br />
 						<span class="property">Object Attribute: <code>xml-roles:search</code></span>
@@ -1684,6 +1896,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-searchbox">
 					<th><a class="role-reference" href="#searchbox"><code>searchbox</code></a></th>
+					<td class="role-computed">
+						<p><code>searchbox</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_TEXT</code></span><br />
 						<span class="property">Object Attribute: <code>text-input-type:search</code></span>
@@ -1704,6 +1919,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-separator">
 					<th><a class="role-reference" href="#separator"><code>separator</code></a> (non-focusable)</th>
+					<td class="role-computed">
+						<p><code>seperator</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_SEPARATOR</code></span>
 					</td>
@@ -1720,6 +1938,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-separator-focusable">
 					<th><a class="role-reference" href="#separator"><code>separator</code></a> (focusable)</th>
+					<td class="role-computed">
+						<p><code>seperator</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_SEPARATOR</code></span><br />
 						<span class="property">Interface: <code>IAccessibleValue</code></span>
@@ -1740,6 +1961,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-slider">
 					<th><a class="role-reference" href="#slider"><code>slider</code></a></th>
+					<td class="role-computed">
+						<p><code>slider</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_SLIDER</code></span><br />
 						<span class="property">Interface: <code>IAcesssibleValue</code></span>
@@ -1760,6 +1984,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-spinbutton">
 					<th><a class="role-reference" href="#spinbutton"><code>spinbutton</code></a></th>
+					<td class="role-computed">
+						<p><code>spinbutton</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_SPINBUTTON</code></span><br />
 						<span class="property">Interface: <code>IAcesssibleValue</code></span>
@@ -1780,6 +2007,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-status">
 					<th><a class="role-reference" href="#status"><code>status</code></a></th>
+					<td class="role-computed">
+						<p><code>status</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_STATUSBAR</code></span><br />
 						<span class="property">Object Attribute: <code>container-live:polite</code></span><br />
@@ -1804,6 +2034,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-strong">
 					<th><a class="role-reference" href="#strong"><code>strong</code></a></th>
+					<td class="role-computed">
+						<p><code>strong</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span><br />
 						<span class="property">Object Attribute: <code>xml-roles:strong</code></span>
@@ -1823,6 +2056,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-subscript">
 					<th><a class="role-reference" href="#subscript"><code>subscript</code></a></th>
+					<td class="role-computed">
+						<p><code>subscript</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br />
 						<span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span><br />
@@ -1842,6 +2078,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-suggestion">
 					<th><a class="role-reference" href="#suggestion"><code>suggestion</code></a></th>
+					<td class="role-computed">
+						<p><code>suggestion</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_SUGGESTION</code></span><br />
 						<span class="property">Object Attribute: <code>xml-roles:suggestion</code></span>
@@ -1861,6 +2100,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-superscript">
 					<th><a class="role-reference" href="#superscript"><code>superscript</code></a></th>
+					<td class="role-computed">
+						<p><code>superscript</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br />
 						<span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span><br />
@@ -1880,6 +2122,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-switch">
 					<th><a class="role-reference" href="#switch"><code>switch</code></a></th>
+					<td class="role-computed">
+						<p><code>switch</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_CHECKBUTTON</code></span><br />
 						<span class="property">Role: <code>IA2_ROLE_TOGGLE_BUTTON</code></span><br />
@@ -1905,6 +2150,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-tab">
 					<th><a class="role-reference" href="#tab"><code>tab</code></a></th>
+					<td class="role-computed">
+						<p><code>tab</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_PAGETAB</code></span><br />
 						<span class="property">State: <code>STATE_SYSTEM_SELECTED</code> if focus is inside <a class="role-reference" href="#tabpanel"><code>tabpanel</code></a> associated with <a class="property-reference" href="#aria-labelledby"><code>aria-labelledby</code></a></span>
@@ -1923,6 +2171,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-table">
 					<th><a class="role-reference" href="#table"><code>table</code></a></th>
+					<td class="role-computed">
+						<p><code>table</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_TABLE</code></span><br />
 						<span class="property">Object Attribute: <code>xml-roles:table</code></span><br />
@@ -1948,6 +2199,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-tablist">
 					<th><a class="role-reference" href="#tablist"><code>tablist</code></a></th>
+					<td class="role-computed">
+						<p><code>tablist</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_PAGETABLIST</code></span><br />
 						<span class="method">Method: <code>IAccessible::accSelect()</code></span><br />
@@ -1969,6 +2223,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-tabpanel">
 					<th><a class="role-reference" href="#tabpanel"><code>tabpanel</code></a></th>
+					<td class="role-computed">
+						<p><code>tabpanel</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_PANE</code> or <code>ROLE_SYSTEM_PROPERTYPAGE</code></span>
 					</td>
@@ -1985,6 +2242,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-term">
 					<th><a class="role-reference" href="#term"><code>term</code></a></th>
+					<td class="role-computed">
+						<p><code>term</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span><br />
 						<span class="property">Object Attribute: <code>xml-roles:term</code></span>
@@ -2007,6 +2267,9 @@ var mappingTableLabels = {
 				the 1.1 branch and uncommented for the master branch
 				<tr id="role-map-text">
 					<th><a class="role-reference" href="#text"><code>text</code></a></th>
+					<td class="role-computed">
+						<p><code></code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_STATICTEXT</code></span>
 					</td>
@@ -2025,6 +2288,9 @@ var mappingTableLabels = {
 
 				<tr id="role-map-textbox">
 					<th><a class="role-reference" href="#textbox"><code>textbox</code></a> when <code>aria-multiline</code> is <code>false</code></th>
+					<td class="role-computed">
+						<p><code>textbox</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_TEXT</code></span><br />
 						<span class="property">State: <code>IA2_STATE_SINGLE_LINE</code></span>
@@ -2044,6 +2310,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-textbox-multiline">
 					<th><a class="role-reference" href="#textbox"><code>textbox</code></a> when <code>aria-multiline</code> is <code>true</code></th>
+					<td class="role-computed">
+						<p><code>textbox</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_TEXT</code></span><br />
 						<span class="property">State: <code>IA2_STATE_MULTI_LINE</code></span>
@@ -2063,6 +2332,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-time">
 					<th><a class="role-reference" href="#time"><code>time</code></a></th>
+					<td class="role-computed">
+						<p><code>time</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br />
 						<span class="property">Object Attribute: <code>xml-roles:time</code></span>
@@ -2083,6 +2355,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-timer">
 					<th><a class="role-reference" href="#timer"><code>timer</code></a></th>
+					<td class="role-computed">
+						<p><code>timer</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Object Attribute: <code>xml-roles:timer</code></span><br />
 						<span class="property">Object Attribute: <code>container-live:off</code></span><br />
@@ -2107,6 +2382,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-toolbar">
 					<th><a class="role-reference" href="#toolbar"><code>toolbar</code></a></th>
+					<td class="role-computed">
+						<p><code>toolbar</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_TOOLBAR</code></span>
 					</td>
@@ -2123,6 +2401,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-tooltip">
 					<th><a class="role-reference" href="#tooltip"><code>tooltip</code></a></th>
+					<td class="role-computed">
+						<p><code>tooltip</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_TOOLTIP</code></span>
 					</td>
@@ -2139,6 +2420,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-tree">
 					<th><a class="role-reference" href="#tree"><code>tree</code></a></th>
+					<td class="role-computed">
+						<p><code>tree</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_OUTLINE</code></span><br />
 						<span class="method">Method: <code>IAccessible::accSelect()</code></span><br />
@@ -2159,6 +2443,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-treegrid">
 					<th><a class="role-reference" href="#treegrid"><code>treegrid</code></a></th>
+					<td class="role-computed">
+						<p><code>treegrid</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_OUTLINE</code></span><br />
 						<span class="property">Interface: <code>IAccessibleTable2</code></span><br />
@@ -2181,6 +2468,9 @@ var mappingTableLabels = {
 				</tr>
 				<tr id="role-map-treeitem">
 					<th><a class="role-reference" href="#treeitem"><code>treeitem</code></a></th>
+					<td class="role-computed">
+						<p><code>treeitem</code></p>
+					</td>
 					<td class="role-msaa-ia2">
 						<span class="property">Role: <code>ROLE_SYSTEM_OUTLINEITEM</code></span><br />
 						<span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Table</a></span>


### PR DESCRIPTION
Closes #166

The githack is easier to review, because the mapping tables code works (unlike in the PR preview, below): https://raw.githack.com/w3c/core-aam/computed-roles/index.html#mapping_role

# Implementation

* WPT tests: [tracking issue for all role tests](https://github.com/web-platform-tests/interop-2023-accessibility-testing/issues/8)
   - https://github.com/web-platform-tests/interop-2023-accessibility-testing/issues/10
  - https://github.com/web-platform-tests/interop-2023-accessibility-testing/issues/11
  - https://github.com/web-platform-tests/interop-2023-accessibility-testing/issues/12
  - https://github.com/web-platform-tests/interop-2023-accessibility-testing/issues/14
  - https://github.com/web-platform-tests/interop-2023-accessibility-testing/issues/15
  - https://github.com/web-platform-tests/interop-2023-accessibility-testing/issues/16
  - https://github.com/web-platform-tests/interop-2023-accessibility-testing/issues/17
  - https://github.com/web-platform-tests/interop-2023-accessibility-testing/issues/19
  - https://github.com/web-platform-tests/interop-2023-accessibility-testing/issues/20
* Implementations: n/a not normative
* Related WebDriver issue: https://github.com/w3c/webdriver/issues/1727


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/pull/167.html" title="Last updated on May 15, 2023, 6:18 PM UTC (0651f71)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/167/5ea3335...0651f71.html" title="Last updated on May 15, 2023, 6:18 PM UTC (0651f71)">Diff</a>