### PR TITLE
split gh pages and tr jobs

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -4,8 +4,18 @@ on:
   push:
     branches: [main]
 jobs:
-  main:
-    name: Build, Validate and Deploy
+  pages:
+    name: Build gh-pages
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: w3c/spec-prod@v2
+        with:
+          GH_PAGES_BRANCH: gh-pages
+          VALIDATE_WEBIDL: false
+          VALIDATE_MARKUP: false
+  tr:
+    name: Build TR
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -13,7 +23,6 @@ jobs:
         with:
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
           W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-aria-admin/2018Sep/0011.html
-          GH_PAGES_BRANCH: gh-pages
           VALIDATE_WEBIDL: false
           VALIDATE_MARKUP: false
           W3C_BUILD_OVERRIDE: |


### PR DESCRIPTION
Closes #????

<!--- IF EDITORIAL or CHORE, delete the rest of this template -->

Split build between gh pages and TR

# Implementation

* WPT tests:
* Implementations (link to issue or when done, link to commit):
   * WebKit:
   * Gecko:
   * Blink:
