### PR TITLE
Add map for `role=image` (synonym of `img`)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1841,6 +1841,50 @@
     </tr>
   </tbody>
 </table>
+<h4 id=role-map-image><code>image</code></h4>
+<table aria-labelledby=role-map-image>
+  <tbody>
+    <tr>
+      <th>ARIA Specification</th>
+      <td>
+        <a class="role-reference" href="#image"><code>image</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>Computed Role</th>
+      <td>
+        <p><code>image</code></p>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2</th>
+      <td>
+        <span class="property">Role: <code>ROLE_SYSTEM_GRAPHIC</code></span><br>
+        <span class="property">Interface: <code>IAccessibleImage</code></span>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr></th>
+      <td>
+        <span class="property">Control Type: <code>Image</code></span>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+      <td>
+        <span class="property">Role: <code>ROLE_IMAGE</code></span><br>
+        <span class="property">Interface: <code>Image</code></span>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
+      <td>
+        <span class="property">AXRole: <code>AXImage</code></span><br>
+        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
+      </td>
+    </tr>
+  </tbody>
+</table>
 <h4 id=role-map-img><code>img</code></h4>
 <table aria-labelledby=role-map-img>
   <tbody>


### PR DESCRIPTION
Closes #169

Add synonym.

# Implementation

* WPT tests: [PR](https://github.com/web-platform-tests/wpt/pull/41643)
* Implementations (link to issue or when done, link to commit):
   * WebKit: already implemented
   * Gecko: already implemented
   * Blink: already implemented


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/pull/187.html" title="Last updated on Aug 25, 2023, 8:37 PM UTC (a1a0400)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/187/356b21f...a1a0400.html" title="Last updated on Aug 25, 2023, 8:37 PM UTC (a1a0400)">Diff</a>