### PR TITLE
Fix AX API aria-haspopup mappings

### DIFF
--- a/index.html
+++ b/index.html
@@ -6096,7 +6096,8 @@
     <tr>
       <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
       <td>
-        <span class="property">Property: <code>Action</code>: <code>AXShowMenu</code></span>
+        <span class="property">Property: <code>AXPopupValue:menu</code></span><br>
+        <span class="property">Action: <code>AXShowMenu</code></span>
       </td>
     </tr>
   </tbody>
@@ -6170,6 +6171,7 @@
     <tr>
       <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
       <td>
+        <span class="property">Property: <code>AXPopupValue:dialog</code></span><br>
         <span class="action">Action: <code>AXShowMenu</code></span>
       </td>
     </tr>
@@ -6208,6 +6210,7 @@
     <tr>
       <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
       <td>
+        <span class="property">Property: <code>AXPopupValue:listbox</code></span><br>
         <span class="action">Action: <code>AXShowMenu</code></span>
       </td>
     </tr>
@@ -6246,6 +6249,7 @@
     <tr>
       <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
       <td>
+        <span class="property">Property: <code>AXPopupValue:menu</code></span><br>
         <span class="action">Action: <code>AXShowMenu</code></span>
       </td>
     </tr>
@@ -6284,6 +6288,7 @@
     <tr>
       <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
       <td>
+        <span class="property">Property: <code>AXPopupValue:tree</code></span><br>
         <span class="action">Action: <code>AXShowMenu</code></span>
       </td>
     </tr>


### PR DESCRIPTION
Closes #151

<!--- IF EDITORIAL or CHORE, delete the rest of this template -->

This change aligns the `aria-haspopup` mappings in the AX API with browser implementations.

# Implementation

* [WPT tests](https://github.com/web-platform-tests/wpt/pull/41685)
* Implementations (link to issue or when done, link to commit):
   * WebKit: [Webkit commit](https://bugs.webkit.org/show_bug.cgi?id=199216), full support
   * Gecko: [Gecko commit](https://bugzilla.mozilla.org/show_bug.cgi?id=1624954), partial support. Gecko doesn't seem to expose `aria-haspopup="true"` the same way `aria-haspopup="menu"` is exposed. [Bug report](https://bugzilla.mozilla.org/show_bug.cgi?id=1850465).
   * Blink: [Blink commit](https://chromium-review.googlesource.com/c/chromium/src/+/2489985) full support


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sivakusayan/core-aam/pull/188.html" title="Last updated on Aug 29, 2023, 4:06 AM UTC (6f23d08)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/188/c7afc4e...sivakusayan:6f23d08.html" title="Last updated on Aug 29, 2023, 4:06 AM UTC (6f23d08)">Diff</a>