### PR TITLE
Update UIA aria-readonly mappings

### DIFF
--- a/index.html
+++ b/index.html
@@ -7486,7 +7486,9 @@
     <tr>
       <th><abbr title="User Interface Automation">UIA</abbr></th>
       <td>
-        <span class="property">Property: <code>Value.IsReadOnly</code>: <code>true</code></span>
+        <span class="property">Property: <code>Value.IsReadOnly</code>: <code>true</code>, if the element implements <a href="https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.provider.ivalueprovider?view=windowsdesktop-7.0"><code>IValueProvider</code></a>.</span><br>
+        <span class="property">Property: <code>RangeValue.IsReadOnly</code>: <code>true</code>, if the element implements <a href="https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.provider.irangevalueprovider?view=windowsdesktop-7.0"><code>IRangeValueProvider</code></a>.</span><br>
+        <span class="property">Property: <code>AriaProperties.readonly</code>: <code>true</code>, if the element implements neither <a href="https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.provider.ivalueprovider?view=windowsdesktop-7.0"><code>IValueProvider</code></a> or <a href="https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.provider.irangevalueprovider?view=windowsdesktop-7.0"><code>IRangeValueProvider</code></a>.</span>
       </td>
     </tr>
     <tr>
@@ -7525,7 +7527,9 @@
     <tr>
       <th><abbr title="User Interface Automation">UIA</abbr></th>
       <td>
-        <span class="property">Property: <code>Value.IsReadOnly</code>: <code>false</code></span>
+        <span class="property">Property: <code>Value.IsReadOnly</code>: <code>false</code>, if the element implements <a href="https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.provider.ivalueprovider?view=windowsdesktop-7.0"><code>IValueProvider</code></a>.</span><br>
+        <span class="property">Property: <code>RangeValue.IsReadOnly</code>: <code>false</code>, if the element implements <a href="https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.provider.irangevalueprovider?view=windowsdesktop-7.0"><code>IRangeValueProvider</code></a>.</span><br>
+        <span class="property">Property: <code>AriaProperties.readonly</code>: <code>false</code>, if the element implements neither <a href="https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.provider.ivalueprovider?view=windowsdesktop-7.0"><code>IValueProvider</code></a> or <a href="https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.provider.irangevalueprovider?view=windowsdesktop-7.0"><code>IRangeValueProvider</code></a>.</span>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Closes #127 

The [UIA `aria-readonly` mappings](https://www.w3.org/TR/core-aam-1.2/#ariaReadonlyTrue) only accounted for controls that implemented the [`IValueProvider`](https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.provider.ivalueprovider?view=windowsdesktop-7.0) interface. Now, it also accounts for controls that implement the [`IRangeValueProvider`](https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.provider.irangevalueprovider?view=windowsdesktop-7.0), and otherwise puts the information in `AriaProperties` if a control implements neither `IValueProvider` nor `IRangeValueProvider`.

# Implementation

* WPT tests: https://github.com/web-platform-tests/wpt/pull/41904
* Implementations (link to issue or when done, link to commit):
   * WebKit: N/A
   * Gecko: N/A, no UIAutomation support.
   * Blink: [Commit](https://chromium-review.googlesource.com/q/I080188507ac4dd0bd7548bec89a9ec069e581b85). Here is the [current code](https://github.com/chromium/chromium/blob/9f42b33b03568f3ee927de27e9e1f6e77a90faa9/ui/accessibility/platform/ax_platform_node_win.cc#L3261). Full support, although Chromium does seem to implement certain UIAutomation patterns (I think) unnecessarily, but functionally everything seems correct.

As an aside, if you want to observe this mapping in Blink, you'll need to use Edge or run Chromium with UIAutomation enabled - the UIAutomation bridge will not map IA2 `STATE_SYSTEM_READONLY` to the `AriaProperties` property when appropriate.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sivakusayan/core-aam/pull/192.html" title="Last updated on Oct 16, 2023, 1:02 AM UTC (f46cdda)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/192/36a2644...sivakusayan:f46cdda.html" title="Last updated on Oct 16, 2023, 1:02 AM UTC (f46cdda)">Diff</a>