### PR TITLE
Editorial: maybe blue tables?

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,9 +8,9 @@
 <script src="common/script/utility.js" class="remove"></script>
 <script src="common/biblio.js" class="remove" defer></script>
 
-<link href="common/css/mapping-tables.css" rel="stylesheet" type="text/css"/>
-<link href="common/css/common.css" rel="stylesheet" type="text/css"/>
-<link href="css/core-aam.css" rel="stylesheet" type="text/css"/>
+<!-- <link href="common/css/mapping-tables.css" rel="stylesheet" type="text/css"/> -->
+<!-- <link href="common/css/common.css" rel="stylesheet" type="text/css"/> -->
+<!-- <link href="css/core-aam.css" rel="stylesheet" type="text/css"/> -->
 
 <script class="remove">
   var respecConfig = {
@@ -403,7 +403,7 @@
   </tbody>
 </table>
 <h4 id=role-map-alertdialog><code>alertdialog</code></h4>
-<table aria-labelledby=role-map-alertdialog>
+<table class=def aria-labelledby=role-map-alertdialog>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -450,7 +450,7 @@
   </tbody>
 </table>
 <h4 id=role-map-application><code>application</code></h4>
-<table aria-labelledby=role-map-application>
+<table class=def aria-labelledby=role-map-application>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -493,7 +493,7 @@
   </tbody>
 </table>
 <h4 id=role-map-article><code>article</code></h4>
-<table aria-labelledby=role-map-article>
+<table class=def aria-labelledby=role-map-article>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -539,7 +539,7 @@
   </tbody>
 </table>
 <h4 id=role-map-banner><code>banner</code></h4>
-<table aria-labelledby=role-map-banner>
+<table class=def aria-labelledby=role-map-banner>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -586,7 +586,7 @@
   </tbody>
 </table>
 <h4 id=role-map-blockquote><code>blockquote</code></h4>
-<table aria-labelledby=role-map-blockquote>
+<table class=def aria-labelledby=role-map-blockquote>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -630,7 +630,7 @@
   </tbody>
 </table>
 <h4 id=role-map-button><code>button</code> with default values for <code>aria-pressed</code> and <code>aria-haspopup</code></h4>
-<table aria-labelledby=role-map-button>
+<table class=def aria-labelledby=role-map-button>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -672,7 +672,7 @@
   </tbody>
 </table>
 <h4 id=role-map-button-haspopup><code>button</code> with non-<code>false</code> value for <code>aria-haspopup</code></h4>
-<table aria-labelledby=role-map-button-haspopup>
+<table class=def aria-labelledby=role-map-button-haspopup>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -714,7 +714,7 @@
   </tbody>
 </table>
 <h4 id=role-map-button-pressed><code>button</code> with defined value for <code>aria-pressed</code></h4>
-<table aria-labelledby=role-map-button-pressed>
+<table class=def aria-labelledby=role-map-button-pressed>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -757,7 +757,7 @@
   </tbody>
 </table>
 <h4 id=role-map-caption><code>caption</code></h4>
-<table aria-labelledby=role-map-caption>
+<table class=def aria-labelledby=role-map-caption>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -800,7 +800,7 @@
   </tbody>
 </table>
 <h4 id=role-map-cell><code>cell</code></h4>
-<table aria-labelledby=role-map-cell>
+<table class=def aria-labelledby=role-map-cell>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -847,7 +847,7 @@
   </tbody>
 </table>
 <h4 id=role-map-checkbox><code>checkbox</code></h4>
-<table aria-labelledby=role-map-checkbox>
+<table class=def aria-labelledby=role-map-checkbox>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -893,7 +893,7 @@
   </tbody>
 </table>
 <h4 id=role-map-code><code>code</code></h4>
-<table aria-labelledby=role-map-code>
+<table class=def aria-labelledby=role-map-code>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -938,7 +938,7 @@
   </tbody>
 </table>
 <h4 id=role-map-columnheader><code>columnheader</code></h4>
-<table aria-labelledby=role-map-columnheader>
+<table class=def aria-labelledby=role-map-columnheader>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -985,7 +985,7 @@
   </tbody>
 </table>
 <h4 id=role-map-combobox><code>combobox</code></h4>
-<table aria-labelledby=role-map-combobox>
+<table class=def aria-labelledby=role-map-combobox>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -1031,7 +1031,7 @@
   </tbody>
 </table>
 <h4 id=role-map-comment><code>comment</code></h4>
-<table aria-labelledby=role-map-comment>
+<table class=def aria-labelledby=role-map-comment>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -1075,7 +1075,7 @@
   </tbody>
 </table>
 <h4 id=role-map-complementary><code>complementary</code></h4>
-<table aria-labelledby=role-map-complementary>
+<table class=def aria-labelledby=role-map-complementary>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -1122,7 +1122,7 @@
   </tbody>
 </table>
 <h4 id=role-map-contentinfo><code>contentinfo</code></h4>
-<table aria-labelledby=role-map-contentinfo>
+<table class=def aria-labelledby=role-map-contentinfo>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -1169,7 +1169,7 @@
   </tbody>
 </table>
 <h4 id=role-map-definition><code>definition</code></h4>
-<table aria-labelledby=role-map-definition>
+<table class=def aria-labelledby=role-map-definition>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -1213,7 +1213,7 @@
   </tbody>
 </table>
 <h4 id=role-map-deletion><code>deletion</code></h4>
-<table aria-labelledby=role-map-deletion>
+<table class=def aria-labelledby=role-map-deletion>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -1258,7 +1258,7 @@
   </tbody>
 </table>
 <h4 id=role-map-dialog><code>dialog</code></h4>
-<table aria-labelledby=role-map-dialog>
+<table class=def aria-labelledby=role-map-dialog>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -1301,7 +1301,7 @@
   </tbody>
 </table>
 <h4 id=role-map-directory><code>directory</code></h4>
-<table aria-labelledby=role-map-directory>
+<table class=def aria-labelledby=role-map-directory>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -1343,7 +1343,7 @@
   </tbody>
 </table>
 <h4 id=role-map-document><code>document</code></h4>
-<table aria-labelledby=role-map-document>
+<table class=def aria-labelledby=role-map-document>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -1386,7 +1386,7 @@
   </tbody>
 </table>
 <h4 id=role-map-emphasis><code>emphasis</code></h4>
-<table aria-labelledby=role-map-emphasis>
+<table class=def aria-labelledby=role-map-emphasis>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -1431,7 +1431,7 @@
   </tbody>
 </table>
 <h4 id=role-map-feed><code>feed</code></h4>
-<table aria-labelledby=role-map-feed>
+<table class=def aria-labelledby=role-map-feed>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -1476,7 +1476,7 @@
   </tbody>
 </table>
 <h4 id=role-map-figure><code>figure</code></h4>
-<table aria-labelledby=role-map-figure>
+<table class=def aria-labelledby=role-map-figure>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -1521,7 +1521,7 @@
   </tbody>
 </table>
 <h4 id=role-map-form><code>form</code> with an accessible name</h4>
-<table aria-labelledby=role-map-form>
+<table class=def aria-labelledby=role-map-form>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -1567,7 +1567,7 @@
   </tbody>
 </table>
 <h4 id=role-map-form-nameless><code>form</code> without an accessible name</h4>
-<table aria-labelledby=role-map-form-nameless>
+<table class=def aria-labelledby=role-map-form-nameless>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -1608,7 +1608,7 @@
   </tbody>
 </table>
 <h4 id=role-map-generic><code>generic</code></h4>
-<table aria-labelledby=role-map-generic>
+<table class=def aria-labelledby=role-map-generic>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -1651,7 +1651,7 @@
   </tbody>
 </table>
 <h4 id=role-map-grid><code>grid</code></h4>
-<table aria-labelledby=role-map-grid>
+<table class=def aria-labelledby=role-map-grid>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -1707,7 +1707,7 @@
   </tbody>
 </table>
 <h4 id=role-map-gridcell><code>gridcell</code></h4>
-<table aria-labelledby=role-map-gridcell>
+<table class=def aria-labelledby=role-map-gridcell>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -1756,7 +1756,7 @@
   </tbody>
 </table>
 <h4 id=role-map-group><code>group</code></h4>
-<table aria-labelledby=role-map-group>
+<table class=def aria-labelledby=role-map-group>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -1798,7 +1798,7 @@
   </tbody>
 </table>
 <h4 id=role-map-heading><code>heading</code></h4>
-<table aria-labelledby=role-map-heading>
+<table class=def aria-labelledby=role-map-heading>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -1842,7 +1842,7 @@
   </tbody>
 </table>
 <h4 id=role-map-image><code>image</code></h4>
-<table aria-labelledby=role-map-image>
+<table class=def aria-labelledby=role-map-image>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -1886,7 +1886,7 @@
   </tbody>
 </table>
 <h4 id=role-map-img><code>img</code></h4>
-<table aria-labelledby=role-map-img>
+<table class=def aria-labelledby=role-map-img>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -1930,7 +1930,7 @@
   </tbody>
 </table>
 <h4 id=role-map-insertion><code>insertion</code></h4>
-<table aria-labelledby=role-map-insertion>
+<table class=def aria-labelledby=role-map-insertion>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -1975,7 +1975,7 @@
   </tbody>
 </table>
 <h4 id=role-map-link><code>link</code></h4>
-<table aria-labelledby=role-map-link>
+<table class=def aria-labelledby=role-map-link>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -2022,7 +2022,7 @@
   </tbody>
 </table>
 <h4 id=role-map-list><code>list</code></h4>
-<table aria-labelledby=role-map-list>
+<table class=def aria-labelledby=role-map-list>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -2065,7 +2065,7 @@
   </tbody>
 </table>
 <h4 id=role-map-listbox><code>listbox</code> not owned by or child of <code>combobox</code></h4>
-<table aria-labelledby=role-map-listbox>
+<table class=def aria-labelledby=role-map-listbox>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -2112,7 +2112,7 @@
   </tbody>
 </table>
 <h4 id=role-map-listbox-in-combobox><code>listbox</code> owned by or child of <code>combobox</code></h4>
-<table aria-labelledby=role-map-listbox-in-combobox>
+<table class=def aria-labelledby=role-map-listbox-in-combobox>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -2159,7 +2159,7 @@
   </tbody>
 </table>
 <h4 id=role-map-listitem><code>listitem</code></h4>
-<table aria-labelledby=role-map-listitem>
+<table class=def aria-labelledby=role-map-listitem>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -2204,7 +2204,7 @@
   </tbody>
 </table>
 <h4 id=role-map-log><code>log</code></h4>
-<table aria-labelledby=role-map-log>
+<table class=def aria-labelledby=role-map-log>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -2255,7 +2255,7 @@
   </tbody>
 </table>
 <h4 id=role-map-main><code>main</code></h4>
-<table aria-labelledby=role-map-main>
+<table class=def aria-labelledby=role-map-main>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -2301,7 +2301,7 @@
   </tbody>
 </table>
 <h4 id=role-map-mark><code>mark</code></h4>
-<table aria-labelledby=role-map-mark>
+<table class=def aria-labelledby=role-map-mark>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -2347,7 +2347,7 @@
   </tbody>
 </table>
 <h4 id=role-map-marquee><code>marquee</code></h4>
-<table aria-labelledby=role-map-marquee>
+<table class=def aria-labelledby=role-map-marquee>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -2396,7 +2396,7 @@
   </tbody>
 </table>
 <h4 id=role-map-math><code>math</code></h4>
-<table aria-labelledby=role-map-math>
+<table class=def aria-labelledby=role-map-math>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -2439,7 +2439,7 @@
   </tbody>
 </table>
 <h4 id=role-map-menu><code>menu</code></h4>
-<table aria-labelledby=role-map-menu>
+<table class=def aria-labelledby=role-map-menu>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -2485,7 +2485,7 @@
   </tbody>
 </table>
 <h4 id=role-map-menubar><code>menubar</code></h4>
-<table aria-labelledby=role-map-menubar>
+<table class=def aria-labelledby=role-map-menubar>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -2531,7 +2531,7 @@
   </tbody>
 </table>
 <h4 id=role-map-menuitem><code>menuitem</code></h4>
-<table aria-labelledby=role-map-menuitem>
+<table class=def aria-labelledby=role-map-menuitem>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -2573,7 +2573,7 @@
   </tbody>
 </table>
 <h4 id=role-map-menuitemcheckbox><code>menuitemcheckbox</code></h4>
-<table aria-labelledby=role-map-menuitemcheckbox>
+<table class=def aria-labelledby=role-map-menuitemcheckbox>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -2621,7 +2621,7 @@
   </tbody>
 </table>
 <h4 id=role-map-menuitemradio><code>menuitemradio</code></h4>
-<table aria-labelledby=role-map-menuitemradio>
+<table class=def aria-labelledby=role-map-menuitemradio>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -2670,7 +2670,7 @@
   </tbody>
 </table>
 <h4 id=role-map-meter><code>meter</code></h4>
-<table aria-labelledby=role-map-meter>
+<table class=def aria-labelledby=role-map-meter>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -2716,7 +2716,7 @@
   </tbody>
 </table>
 <h4 id=role-map-navigation><code>navigation</code></h4>
-<table aria-labelledby=role-map-navigation>
+<table class=def aria-labelledby=role-map-navigation>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -2762,7 +2762,7 @@
   </tbody>
 </table>
 <h4 id=role-map-none><code>none</code></h4>
-<table aria-labelledby=role-map-none>
+<table class=def aria-labelledby=role-map-none>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -2803,7 +2803,7 @@
   </tbody>
 </table>
 <h4 id=role-map-note><code>note</code></h4>
-<table aria-labelledby=role-map-note>
+<table class=def aria-labelledby=role-map-note>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -2846,7 +2846,7 @@
   </tbody>
 </table>
 <h4 id=role-map-option><code>option</code> not inside <code>combobox</code></h4>
-<table aria-labelledby=role-map-option>
+<table class=def aria-labelledby=role-map-option>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -2893,7 +2893,7 @@
   </tbody>
 </table>
 <h4 id=role-map-option-in-combobox><code>option</code> inside <code>combobox</code></h4>
-<table aria-labelledby=role-map-option-in-combobox>
+<table class=def aria-labelledby=role-map-option-in-combobox>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -2940,7 +2940,7 @@
   </tbody>
 </table>
 <h4 id=role-map-paragraph><code>paragraph</code></h4>
-<table aria-labelledby=role-map-paragraph>
+<table class=def aria-labelledby=role-map-paragraph>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -2983,7 +2983,7 @@
   </tbody>
 </table>
 <h4 id=role-map-presentation><code>presentation</code></h4>
-<table aria-labelledby=role-map-presentation>
+<table class=def aria-labelledby=role-map-presentation>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -3024,7 +3024,7 @@
   </tbody>
 </table>
 <h4 id=role-map-progressbar><code>progressbar</code></h4>
-<table aria-labelledby=role-map-progressbar>
+<table class=def aria-labelledby=role-map-progressbar>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -3071,7 +3071,7 @@
   </tbody>
 </table>
 <h4 id=role-map-radio><code>radio</code></h4>
-<table aria-labelledby=role-map-radio>
+<table class=def aria-labelledby=role-map-radio>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -3119,7 +3119,7 @@
   </tbody>
 </table>
 <h4 id=role-map-radiogroup><code>radiogroup</code></h4>
-<table aria-labelledby=role-map-radiogroup>
+<table class=def aria-labelledby=role-map-radiogroup>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -3161,7 +3161,7 @@
   </tbody>
 </table>
 <h4 id=role-map-region><code>region</code> with an accessible name</h4>
-<table aria-labelledby=role-map-region>
+<table class=def aria-labelledby=role-map-region>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -3208,7 +3208,7 @@
   </tbody>
 </table>
 <h4 id=role-map-region-nameless><code>region</code> without an accessible name</h4>
-<table aria-labelledby=role-map-region-nameless>
+<table class=def aria-labelledby=role-map-region-nameless>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -3249,7 +3249,7 @@
   </tbody>
 </table>
 <h4 id=role-map-row><code>row</code> not inside <code>treegrid</code></h4>
-<table aria-labelledby=role-map-row>
+<table class=def aria-labelledby=role-map-row>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -3293,7 +3293,7 @@
   </tbody>
 </table>
 <h4 id=role-map-row-in-treegrid><code>row</code> inside <code>treegrid</code></h4>
-<table aria-labelledby=role-map-row-in-treegrid>
+<table class=def aria-labelledby=role-map-row-in-treegrid>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -3337,7 +3337,7 @@
   </tbody>
 </table>
 <h4 id=role-map-rowgroup><code>rowgroup</code></h4>
-<table aria-labelledby=role-map-rowgroup>
+<table class=def aria-labelledby=role-map-rowgroup>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -3378,7 +3378,7 @@
   </tbody>
 </table>
 <h4 id=role-map-rowheader><code>rowheader</code></h4>
-<table aria-labelledby=role-map-rowheader>
+<table class=def aria-labelledby=role-map-rowheader>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -3422,7 +3422,7 @@
   </tbody>
 </table>
 <h4 id=role-map-scrollbar><code>scrollbar</code></h4>
-<table aria-labelledby=role-map-scrollbar>
+<table class=def aria-labelledby=role-map-scrollbar>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -3468,7 +3468,7 @@
   </tbody>
 </table>
 <h4 id=role-map-search><code>search</code></h4>
-<table aria-labelledby=role-map-search>
+<table class=def aria-labelledby=role-map-search>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -3514,7 +3514,7 @@
   </tbody>
 </table>
 <h4 id=role-map-searchbox><code>searchbox</code></h4>
-<table aria-labelledby=role-map-searchbox>
+<table class=def aria-labelledby=role-map-searchbox>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -3560,7 +3560,7 @@
   </tbody>
 </table>
 <h4 id=role-map-separator><code>separator</code> (non-focusable)</h4>
-<table aria-labelledby=role-map-separator>
+<table class=def aria-labelledby=role-map-separator>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -3602,7 +3602,7 @@
   </tbody>
 </table>
 <h4 id=role-map-separator-focusable><code>separator</code> (focusable)</h4>
-<table aria-labelledby=role-map-separator-focusable>
+<table class=def aria-labelledby=role-map-separator-focusable>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -3648,7 +3648,7 @@
   </tbody>
 </table>
 <h4 id=role-map-slider><code>slider</code></h4>
-<table aria-labelledby=role-map-slider>
+<table class=def aria-labelledby=role-map-slider>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -3694,7 +3694,7 @@
   </tbody>
 </table>
 <h4 id=role-map-spinbutton><code>spinbutton</code></h4>
-<table aria-labelledby=role-map-spinbutton>
+<table class=def aria-labelledby=role-map-spinbutton>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -3740,7 +3740,7 @@
   </tbody>
 </table>
 <h4 id=role-map-status><code>status</code></h4>
-<table aria-labelledby=role-map-status>
+<table class=def aria-labelledby=role-map-status>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -3790,7 +3790,7 @@
   </tbody>
 </table>
 <h4 id=role-map-strong><code>strong</code></h4>
-<table aria-labelledby=role-map-strong>
+<table class=def aria-labelledby=role-map-strong>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -3835,7 +3835,7 @@
   </tbody>
 </table>
 <h4 id=role-map-subscript><code>subscript</code></h4>
-<table aria-labelledby=role-map-subscript>
+<table class=def aria-labelledby=role-map-subscript>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -3880,7 +3880,7 @@
   </tbody>
 </table>
 <h4 id=role-map-suggestion><code>suggestion</code></h4>
-<table aria-labelledby=role-map-suggestion>
+<table class=def aria-labelledby=role-map-suggestion>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -3925,7 +3925,7 @@
   </tbody>
 </table>
 <h4 id=role-map-superscript><code>superscript</code></h4>
-<table aria-labelledby=role-map-superscript>
+<table class=def aria-labelledby=role-map-superscript>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -3970,7 +3970,7 @@
   </tbody>
 </table>
 <h4 id=role-map-switch><code>switch</code></h4>
-<table aria-labelledby=role-map-switch>
+<table class=def aria-labelledby=role-map-switch>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -4021,7 +4021,7 @@
   </tbody>
 </table>
 <h4 id=role-map-tab><code>tab</code></h4>
-<table aria-labelledby=role-map-tab>
+<table class=def aria-labelledby=role-map-tab>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -4065,7 +4065,7 @@
   </tbody>
 </table>
 <h4 id=role-map-table><code>table</code></h4>
-<table aria-labelledby=role-map-table>
+<table class=def aria-labelledby=role-map-table>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -4116,7 +4116,7 @@
   </tbody>
 </table>
 <h4 id=role-map-tablist><code>tablist</code></h4>
-<table aria-labelledby=role-map-tablist>
+<table class=def aria-labelledby=role-map-tablist>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -4163,7 +4163,7 @@
   </tbody>
 </table>
 <h4 id=role-map-tabpanel><code>tabpanel</code></h4>
-<table aria-labelledby=role-map-tabpanel>
+<table class=def aria-labelledby=role-map-tabpanel>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -4205,7 +4205,7 @@
   </tbody>
 </table>
 <h4 id=role-map-term><code>term</code></h4>
-<table aria-labelledby=role-map-term>
+<table class=def aria-labelledby=role-map-term>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -4249,7 +4249,7 @@
   </tbody>
 </table>
 <h4 id=role-map-textbox><code>textbox</code> when <code>aria-multiline</code> is <code>false</code></h4>
-<table aria-labelledby=role-map-textbox>
+<table class=def aria-labelledby=role-map-textbox>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -4294,7 +4294,7 @@
   </tbody>
 </table>
 <h4 id=role-map-textbox-multiline><code>textbox</code> when <code>aria-multiline</code> is <code>true</code></h4>
-<table aria-labelledby=role-map-textbox-multiline>
+<table class=def aria-labelledby=role-map-textbox-multiline>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -4339,7 +4339,7 @@
   </tbody>
 </table>
 <h4 id=role-map-time><code>time</code></h4>
-<table aria-labelledby=role-map-time>
+<table class=def aria-labelledby=role-map-time>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -4385,7 +4385,7 @@
   </tbody>
 </table>
 <h4 id=role-map-timer><code>timer</code></h4>
-<table aria-labelledby=role-map-timer>
+<table class=def aria-labelledby=role-map-timer>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -4435,7 +4435,7 @@
   </tbody>
 </table>
 <h4 id=role-map-toolbar><code>toolbar</code></h4>
-<table aria-labelledby=role-map-toolbar>
+<table class=def aria-labelledby=role-map-toolbar>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -4477,7 +4477,7 @@
   </tbody>
 </table>
 <h4 id=role-map-tooltip><code>tooltip</code></h4>
-<table aria-labelledby=role-map-tooltip>
+<table class=def aria-labelledby=role-map-tooltip>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -4519,7 +4519,7 @@
   </tbody>
 </table>
 <h4 id=role-map-tree><code>tree</code></h4>
-<table aria-labelledby=role-map-tree>
+<table class=def aria-labelledby=role-map-tree>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -4565,7 +4565,7 @@
   </tbody>
 </table>
 <h4 id=role-map-treegrid><code>treegrid</code></h4>
-<table aria-labelledby=role-map-treegrid>
+<table class=def aria-labelledby=role-map-treegrid>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -4613,7 +4613,7 @@
   </tbody>
 </table>
 <h4 id=role-map-treeitem><code>treeitem</code></h4>
-<table aria-labelledby=role-map-treeitem>
+<table class=def aria-labelledby=role-map-treeitem>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -4690,7 +4690,7 @@
       <p>In other cases, it is mandatory that the state/property not be mapped, since exposing it implies a related affordance.  An example is <a class="state-reference" href="#aria-grabbed"><code>aria-grabbed</code></a>.  Its absence not only indicates that the accessible object is not grabbed, but further defines it as not grab-able.  These cases are marked as "Not mapped" without an asterisk.  </p> 
     </section>
 <h4 id=ariaActiveDescendant><code>aria-activedescendant</code></h4>
-<table aria-labelledby=ariaActiveDescendant>
+<table class=def aria-labelledby=ariaActiveDescendant>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -4726,7 +4726,7 @@
   </tbody>
 </table>
 <h4 id=ariaAtomicTrue><code>aria-atomic</code>=<code>true</code></h4>
-<table aria-labelledby=ariaAtomicTrue>
+<table class=def aria-labelledby=ariaAtomicTrue>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -4771,7 +4771,7 @@
   </tbody>
 </table>
 <h4 id=ariaAtomicFalse><code>aria-atomic</code>=<code>false</code></h4>
-<table aria-labelledby=ariaAtomicFalse>
+<table class=def aria-labelledby=ariaAtomicFalse>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -4818,7 +4818,7 @@
   </tbody>
 </table>
 <h4 id=ariaAutocompleteInlineListBoth><code>aria-autocomplete</code>=<code>inline</code>, <code>list</code>, or <code>both</code></h4>
-<table aria-labelledby=ariaAutocompleteInlineListBoth>
+<table class=def aria-labelledby=ariaAutocompleteInlineListBoth>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -4855,7 +4855,7 @@
   </tbody>
 </table>
 <h4 id=ariaAutocompleteNone><code>aria-autocomplete</code>=<code>none</code></h4>
-<table aria-labelledby=ariaAutocompleteNone>
+<table class=def aria-labelledby=ariaAutocompleteNone>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -4890,7 +4890,7 @@
   </tbody>
 </table>
 <h4 id=ariaBraillelabel><code>aria-braillelabel</code></h4>
-<table aria-labelledby=ariaBraillelabel>
+<table class=def aria-labelledby=ariaBraillelabel>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -4925,7 +4925,7 @@
   </tbody>
 </table>
 <h4 id=ariaBrailleroledescription><code>aria-brailleroledescription</code></h4>
-<table aria-labelledby=ariaBrailleroledescription>
+<table class=def aria-labelledby=ariaBrailleroledescription>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -4960,7 +4960,7 @@
   </tbody>
 </table>
 <h4 id=ariaBrailleroledescriptionUndefined><code>aria-brailleroledescription</code> is undefined or the empty string</h4>
-<table aria-labelledby=ariaBrailleroledescriptionUndefined>
+<table class=def aria-labelledby=ariaBrailleroledescriptionUndefined>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -4995,7 +4995,7 @@
   </tbody>
 </table>
 <h4 id=ariaBusyTrue><code>aria-busy</code>=<code>true</code></h4>
-<table aria-labelledby=ariaBusyTrue>
+<table class=def aria-labelledby=ariaBusyTrue>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -5030,7 +5030,7 @@
   </tbody>
 </table>
 <h4 id=ariaBusyFalse><code>aria-busy</code>=<code>false</code></h4>
-<table aria-labelledby=ariaBusyFalse>
+<table class=def aria-labelledby=ariaBusyFalse>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -5065,7 +5065,7 @@
   </tbody>
 </table>
 <h4 id=ariaCheckedTrue><code>aria-checked</code>=<code>true</code></h4>
-<table aria-labelledby=ariaCheckedTrue>
+<table class=def aria-labelledby=ariaCheckedTrue>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -5104,7 +5104,7 @@
   </tbody>
 </table>
 <h4 id=ariaCheckedFalse><code>aria-checked</code>=<code>false</code></h4>
-<table aria-labelledby=ariaCheckedFalse>
+<table class=def aria-labelledby=ariaCheckedFalse>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -5143,7 +5143,7 @@
   </tbody>
 </table>
 <h4 id=ariaCheckedMixed><code>aria-checked</code>=<code>mixed</code></h4>
-<table aria-labelledby=ariaCheckedMixed>
+<table class=def aria-labelledby=ariaCheckedMixed>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -5182,7 +5182,7 @@
   </tbody>
 </table>
 <h4 id=ariaCheckedUndefined><code>aria-checked</code> is undefined</h4>
-<table aria-labelledby=ariaCheckedUndefined>
+<table class=def aria-labelledby=ariaCheckedUndefined>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -5217,7 +5217,7 @@
   </tbody>
 </table>
 <h4 id=ariaColCount><code>aria-colcount</code></h4>
-<table aria-labelledby=ariaColCount>
+<table class=def aria-labelledby=ariaColCount>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -5254,7 +5254,7 @@
   </tbody>
 </table>
 <h4 id=ariaColIndex><code>aria-colindex</code></h4>
-<table aria-labelledby=ariaColIndex>
+<table class=def aria-labelledby=ariaColIndex>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -5291,7 +5291,7 @@
   </tbody>
 </table>
 <h4 id=ariaColIndexText><code>aria-colindextext</code></h4>
-<table aria-labelledby=ariaColIndexText>
+<table class=def aria-labelledby=ariaColIndexText>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -5326,7 +5326,7 @@
   </tbody>
 </table>
 <h4 id=ariaColSpan><code>aria-colspan</code></h4>
-<table aria-labelledby=ariaColSpan>
+<table class=def aria-labelledby=ariaColSpan>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -5363,7 +5363,7 @@
   </tbody>
 </table>
 <h4 id=ariaControls><code>aria-controls</code></h4>
-<table aria-labelledby=ariaControls>
+<table class=def aria-labelledby=ariaControls>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -5402,7 +5402,7 @@
   </tbody>
 </table>
 <h4 id=ariaCurrent><code>aria-current</code> with non-<code>false</code> allowed value</h4>
-<table aria-labelledby=ariaCurrent>
+<table class=def aria-labelledby=ariaCurrent>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -5438,7 +5438,7 @@
   </tbody>
 </table>
 <h4 id=ariaCurrentUnrecognizedValue><code>aria-current</code> with unrecognized value</h4>
-<table aria-labelledby=ariaCurrentUnrecognizedValue>
+<table class=def aria-labelledby=ariaCurrentUnrecognizedValue>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -5474,7 +5474,7 @@
   </tbody>
 </table>
 <h4 id=ariaCurrentUndefined><code>aria-current</code> is <code>false</code> or undefined</h4>
-<table aria-labelledby=ariaCurrentUndefined>
+<table class=def aria-labelledby=ariaCurrentUndefined>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -5509,7 +5509,7 @@
   </tbody>
 </table>
 <h4 id=ariaDescribedBy><code>aria-describedby</code></h4>
-<table aria-labelledby=ariaDescribedBy>
+<table class=def aria-labelledby=ariaDescribedBy>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -5553,7 +5553,7 @@
   </tbody>
 </table>
 <h4 id=ariaDescription><code>aria-description</code></h4>
-<table aria-labelledby=ariaDescription>
+<table class=def aria-labelledby=ariaDescription>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -5592,7 +5592,7 @@
   </tbody>
 </table>
 <h4 id=ariaDetails><code>aria-details</code></h4>
-<table aria-labelledby=ariaDetails>
+<table class=def aria-labelledby=ariaDetails>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -5631,7 +5631,7 @@
   </tbody>
 </table>
 <h4 id=ariaDisabledTrue><code>aria-disabled</code>=<code>true</code></h4>
-<table aria-labelledby=ariaDisabledTrue>
+<table class=def aria-labelledby=ariaDisabledTrue>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -5667,7 +5667,7 @@
   </tbody>
 </table>
 <h4 id=ariaDisabledFalse><code>aria-disabled</code>=<code>false</code></h4>
-<table aria-labelledby=ariaDisabledFalse>
+<table class=def aria-labelledby=ariaDisabledFalse>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -5702,7 +5702,7 @@
   </tbody>
 </table>
 <h4 id=ariaDropeffectMoveLinkExecutePopup><code>aria-dropeffect</code>=<code>copy</code>, <code>move</code>, <code>link</code>, <code>execute</code>, or <code>popup</code></h4>
-<table aria-labelledby=ariaDropeffectMoveLinkExecutePopup>
+<table class=def aria-labelledby=ariaDropeffectMoveLinkExecutePopup>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -5737,7 +5737,7 @@
   </tbody>
 </table>
 <h4 id=ariaDropeffectNone><code>aria-dropeffect</code>=<code>none</code></h4>
-<table aria-labelledby=ariaDropeffectNone>
+<table class=def aria-labelledby=ariaDropeffectNone>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -5774,7 +5774,7 @@
   </tbody>
 </table>
 <h4 id=ariaErrorMessage><code>aria-errormessage</code></h4>
-<table aria-labelledby=ariaErrorMessage>
+<table class=def aria-labelledby=ariaErrorMessage>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -5813,7 +5813,7 @@
   </tbody>
 </table>
 <h4 id=ariaExpandedTrue><code>aria-expanded</code>=<code>true</code></h4>
-<table aria-labelledby=ariaExpandedTrue>
+<table class=def aria-labelledby=ariaExpandedTrue>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -5849,7 +5849,7 @@
   </tbody>
 </table>
 <h4 id=ariaExpandedFalse><code>aria-expanded</code>=<code>false</code></h4>
-<table aria-labelledby=ariaExpandedFalse>
+<table class=def aria-labelledby=ariaExpandedFalse>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -5885,7 +5885,7 @@
   </tbody>
 </table>
 <h4 id=ariaExpandedUndefined><code>aria-expanded</code> is undefined</h4>
-<table aria-labelledby=ariaExpandedUndefined>
+<table class=def aria-labelledby=ariaExpandedUndefined>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -5920,7 +5920,7 @@
   </tbody>
 </table>
 <h4 id=ariaFlowto><code>aria-flowto</code></h4>
-<table aria-labelledby=ariaFlowto>
+<table class=def aria-labelledby=ariaFlowto>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -5959,7 +5959,7 @@
   </tbody>
 </table>
 <h4 id=ariaGrabbedTrue><code>aria-grabbed</code>=<code>true</code></h4>
-<table aria-labelledby=ariaGrabbedTrue>
+<table class=def aria-labelledby=ariaGrabbedTrue>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -5994,7 +5994,7 @@
   </tbody>
 </table>
 <h4 id=ariaGrabbedFalse><code>aria-grabbed</code>=<code>false</code></h4>
-<table aria-labelledby=ariaGrabbedFalse>
+<table class=def aria-labelledby=ariaGrabbedFalse>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -6029,7 +6029,7 @@
   </tbody>
 </table>
 <h4 id=ariaGrabbedUndefined><code>aria-grabbed</code> is undefined</h4>
-<table aria-labelledby=ariaGrabbedUndefined>
+<table class=def aria-labelledby=ariaGrabbedUndefined>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -6064,7 +6064,7 @@
   </tbody>
 </table>
 <h4 id=ariaHaspopupTrue><code>aria-haspopup</code>=<code>true</code></h4>
-<table aria-labelledby=ariaHaspopupTrue>
+<table class=def aria-labelledby=ariaHaspopupTrue>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -6103,7 +6103,7 @@
   </tbody>
 </table>
 <h4 id=ariaHaspopupFalse><code>aria-haspopup</code>=<code>false</code></h4>
-<table aria-labelledby=ariaHaspopupFalse>
+<table class=def aria-labelledby=ariaHaspopupFalse>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -6139,7 +6139,7 @@
   </tbody>
 </table>
 <h4 id=ariaHaspopupDialog><code>aria-haspopup</code>=<code>dialog</code></h4>
-<table aria-labelledby=ariaHaspopupDialog>
+<table class=def aria-labelledby=ariaHaspopupDialog>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -6178,7 +6178,7 @@
   </tbody>
 </table>
 <h4 id=ariaHaspopupListbox><code>aria-haspopup</code>=<code>listbox</code></h4>
-<table aria-labelledby=ariaHaspopupListbox>
+<table class=def aria-labelledby=ariaHaspopupListbox>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -6217,7 +6217,7 @@
   </tbody>
 </table>
 <h4 id=ariaHaspopupMenu><code>aria-haspopup</code>=<code>menu</code></h4>
-<table aria-labelledby=ariaHaspopupMenu>
+<table class=def aria-labelledby=ariaHaspopupMenu>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -6256,7 +6256,7 @@
   </tbody>
 </table>
 <h4 id=ariaHaspopupTree><code>aria-haspopup</code>=<code>tree</code></h4>
-<table aria-labelledby=ariaHaspopupTree>
+<table class=def aria-labelledby=ariaHaspopupTree>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -6295,7 +6295,7 @@
   </tbody>
 </table>
 <h4 id=ariaHiddenTrue><code>aria-hidden</code>=<code>true</code> on unfocused element</h4>
-<table aria-labelledby=ariaHiddenTrue>
+<table class=def aria-labelledby=ariaHiddenTrue>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -6334,7 +6334,7 @@
   </tbody>
 </table>
 <h4 id=ariaHiddenTrueElementExposed><code>aria-hidden</code>=<code>true</code> when element is focused or fires an accessibility event</h4>
-<table aria-labelledby=ariaHiddenTrueElementExposed>
+<table class=def aria-labelledby=ariaHiddenTrueElementExposed>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -6373,7 +6373,7 @@
   </tbody>
 </table>
 <h4 id=ariaHiddenFalse><code>aria-hidden</code>=<code>false</code></h4>
-<table aria-labelledby=ariaHiddenFalse>
+<table class=def aria-labelledby=ariaHiddenFalse>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -6408,7 +6408,7 @@
   </tbody>
 </table>
 <h4 id=ariaInvalidTrue><code>aria-invalid</code>=<code>true</code></h4>
-<table aria-labelledby=ariaInvalidTrue>
+<table class=def aria-labelledby=ariaInvalidTrue>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -6445,7 +6445,7 @@
   </tbody>
 </table>
 <h4 id=ariaInvalidFalse><code>aria-invalid</code>=<code>false</code></h4>
-<table aria-labelledby=ariaInvalidFalse>
+<table class=def aria-labelledby=ariaInvalidFalse>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -6480,7 +6480,7 @@
   </tbody>
 </table>
 <h4 id=ariaInvalidSpellingGrammar><code>aria-invalid</code>=<code>spelling</code> or <code>grammar</code></h4>
-<table aria-labelledby=ariaInvalidSpellingGrammar>
+<table class=def aria-labelledby=ariaInvalidSpellingGrammar>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -6517,7 +6517,7 @@
   </tbody>
 </table>
 <h4 id=ariaInvalidUnrecognizedValue><code>aria-invalid</code> with unrecognized value</h4>
-<table aria-labelledby=ariaInvalidUnrecognizedValue>
+<table class=def aria-labelledby=ariaInvalidUnrecognizedValue>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -6554,7 +6554,7 @@
   </tbody>
 </table>
 <h4 id=ariaKeyshortcuts><code>aria-keyshortcuts</code></h4>
-<table aria-labelledby=ariaKeyshortcuts>
+<table class=def aria-labelledby=ariaKeyshortcuts>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -6589,7 +6589,7 @@
   </tbody>
 </table>
 <h4 id=ariaLabel><code>aria-label</code></h4>
-<table aria-labelledby=ariaLabel>
+<table class=def aria-labelledby=ariaLabel>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -6628,7 +6628,7 @@
   </tbody>
 </table>
 <h4 id=ariaLabelledBy><code>aria-labelledby</code></h4>
-<table aria-labelledby=ariaLabelledBy>
+<table class=def aria-labelledby=ariaLabelledBy>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -6674,7 +6674,7 @@
   </tbody>
 </table>
 <h4 id=ariaLevel><code>aria-level</code> on non-<code>heading</code></h4>
-<table aria-labelledby=ariaLevel>
+<table class=def aria-labelledby=ariaLevel>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -6711,7 +6711,7 @@
   </tbody>
 </table>
 <h4 id=ariaLevelHeading><code>aria-level</code> on <code>heading</code></h4>
-<table aria-labelledby=ariaLevelHeading>
+<table class=def aria-labelledby=ariaLevelHeading>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -6747,7 +6747,7 @@
   </tbody>
 </table>
 <h4 id=ariaLiveAssertive><code>aria-live</code>=<code>assertive</code></h4>
-<table aria-labelledby=ariaLiveAssertive>
+<table class=def aria-labelledby=ariaLiveAssertive>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -6790,7 +6790,7 @@
   </tbody>
 </table>
 <h4 id=ariaLivePolite><code>aria-live</code>=<code>polite</code></h4>
-<table aria-labelledby=ariaLivePolite>
+<table class=def aria-labelledby=ariaLivePolite>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -6833,7 +6833,7 @@
   </tbody>
 </table>
 <h4 id=ariaLiveOff><code>aria-live</code>=<code>off</code></h4>
-<table aria-labelledby=ariaLiveOff>
+<table class=def aria-labelledby=ariaLiveOff>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -6872,7 +6872,7 @@
   </tbody>
 </table>
 <h4 id=ariaModalTrue><code>aria-modal</code>=<code>true</code></h4>
-<table aria-labelledby=ariaModalTrue>
+<table class=def aria-labelledby=ariaModalTrue>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -6907,7 +6907,7 @@
   </tbody>
 </table>
 <h4 id=ariaModalFalse><code>aria-modal</code>=<code>false</code></h4>
-<table aria-labelledby=ariaModalFalse>
+<table class=def aria-labelledby=ariaModalFalse>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -6942,7 +6942,7 @@
   </tbody>
 </table>
 <h4 id=ariaMultilineTrue><code>aria-multiline</code>=<code>true</code></h4>
-<table aria-labelledby=ariaMultilineTrue>
+<table class=def aria-labelledby=ariaMultilineTrue>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -6980,7 +6980,7 @@
   </tbody>
 </table>
 <h4 id=ariaMultilineFalse><code>aria-multiline</code>=<code>false</code></h4>
-<table aria-labelledby=ariaMultilineFalse>
+<table class=def aria-labelledby=ariaMultilineFalse>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -7018,7 +7018,7 @@
   </tbody>
 </table>
 <h4 id=ariaMultiselectableTrue><code>aria-multiselectable</code>=<code>true</code></h4>
-<table aria-labelledby=ariaMultiselectableTrue>
+<table class=def aria-labelledby=ariaMultiselectableTrue>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -7058,7 +7058,7 @@
   </tbody>
 </table>
 <h4 id=ariaMultiselectableFalse><code>aria-multiselectable</code>=<code>false</code></h4>
-<table aria-labelledby=ariaMultiselectableFalse>
+<table class=def aria-labelledby=ariaMultiselectableFalse>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -7095,7 +7095,7 @@
   </tbody>
 </table>
 <h4 id=ariaOrientationHorizontal><code>aria-orientation</code>=<code>horizontal</code></h4>
-<table aria-labelledby=ariaOrientationHorizontal>
+<table class=def aria-labelledby=ariaOrientationHorizontal>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -7132,7 +7132,7 @@
   </tbody>
 </table>
 <h4 id=ariaOrientationVertical><code>aria-orientation</code>=<code>vertical</code></h4>
-<table aria-labelledby=ariaOrientationVertical>
+<table class=def aria-labelledby=ariaOrientationVertical>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -7169,7 +7169,7 @@
   </tbody>
 </table>
 <h4 id=ariaOrientationUndefined><code>aria-orientation</code> is undefined</h4>
-<table aria-labelledby=ariaOrientationUndefined>
+<table class=def aria-labelledby=ariaOrientationUndefined>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -7205,7 +7205,7 @@
   </tbody>
 </table>
 <h4 id=ariaOwns><code>aria-owns</code></h4>
-<table aria-labelledby=ariaOwns>
+<table class=def aria-labelledby=ariaOwns>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -7246,7 +7246,7 @@
   </tbody>
 </table>
 <h4 id=ariaPlaceholder><code>aria-placeholder</code></h4>
-<table aria-labelledby=ariaPlaceholder>
+<table class=def aria-labelledby=ariaPlaceholder>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -7281,7 +7281,7 @@
   </tbody>
 </table>
 <h4 id=ariaPosinset><code>aria-posinset</code></h4>
-<table aria-labelledby=ariaPosinset>
+<table class=def aria-labelledby=ariaPosinset>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -7320,7 +7320,7 @@
   </tbody>
 </table>
 <h4 id=ariaPressedTrue><code>aria-pressed</code>=<code>true</code></h4>
-<table aria-labelledby=ariaPressedTrue>
+<table class=def aria-labelledby=ariaPressedTrue>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -7358,7 +7358,7 @@
   </tbody>
 </table>
 <h4 id=ariaPressedMixed><code>aria-pressed</code>=<code>mixed</code></h4>
-<table aria-labelledby=ariaPressedMixed>
+<table class=def aria-labelledby=ariaPressedMixed>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -7396,7 +7396,7 @@
   </tbody>
 </table>
 <h4 id=ariaPressedFalse><code>aria-pressed</code>=<code>false</code></h4>
-<table aria-labelledby=ariaPressedFalse>
+<table class=def aria-labelledby=ariaPressedFalse>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -7434,7 +7434,7 @@
   </tbody>
 </table>
 <h4 id=ariaPressedUndefined><code>aria-pressed</code> is undefined</h4>
-<table aria-labelledby=ariaPressedUndefined>
+<table class=def aria-labelledby=ariaPressedUndefined>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -7469,7 +7469,7 @@
   </tbody>
 </table>
 <h4 id=ariaReadonlyTrue><code>aria-readonly</code>=<code>true</code></h4>
-<table aria-labelledby=ariaReadonlyTrue>
+<table class=def aria-labelledby=ariaReadonlyTrue>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -7507,7 +7507,7 @@
   </tbody>
 </table>
 <h4 id=ariaReadonlyFalse><code>aria-readonly</code>=<code>false</code></h4>
-<table aria-labelledby=ariaReadonlyFalse>
+<table class=def aria-labelledby=ariaReadonlyFalse>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -7543,7 +7543,7 @@
   </tbody>
 </table>
 <h4 id=ariaReadonlyUnspecifiedOnGridcell><code>aria-readonly</code> is unspecified on <code>gridcell</code></h4>
-<table aria-labelledby=ariaReadonlyUnspecifiedOnGridcell>
+<table class=def aria-labelledby=ariaReadonlyUnspecifiedOnGridcell>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -7578,7 +7578,7 @@
   </tbody>
 </table>
 <h4 id=ariaRelevant><code>aria-relevant</code></h4>
-<table aria-labelledby=ariaRelevant>
+<table class=def aria-labelledby=ariaRelevant>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -7621,7 +7621,7 @@
   </tbody>
 </table>
 <h4 id=ariaRequiredTrue><code>aria-required</code>=<code>true</code></h4>
-<table aria-labelledby=ariaRequiredTrue>
+<table class=def aria-labelledby=ariaRequiredTrue>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -7656,7 +7656,7 @@
   </tbody>
 </table>
 <h4 id=ariaRequiredFalse><code>aria-required</code>=<code>false</code></h4>
-<table aria-labelledby=ariaRequiredFalse>
+<table class=def aria-labelledby=ariaRequiredFalse>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -7691,7 +7691,7 @@
   </tbody>
 </table>
 <h4 id=ariaRoleDescription><code>aria-roledescription</code></h4>
-<table aria-labelledby=ariaRoleDescription>
+<table class=def aria-labelledby=ariaRoleDescription>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -7726,7 +7726,7 @@
   </tbody>
 </table>
 <h4 id=ariaRoleDescriptionEmptyString><code>aria-roledescription</code> is undefined or the empty string</h4>
-<table aria-labelledby=ariaRoleDescriptionEmptyString>
+<table class=def aria-labelledby=ariaRoleDescriptionEmptyString>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -7761,7 +7761,7 @@
   </tbody>
 </table>
 <h4 id=ariaRowCount><code>aria-rowcount</code></h4>
-<table aria-labelledby=ariaRowCount>
+<table class=def aria-labelledby=ariaRowCount>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -7798,7 +7798,7 @@
   </tbody>
 </table>
 <h4 id=ariaRowIndex><code>aria-rowindex</code></h4>
-<table aria-labelledby=ariaRowIndex>
+<table class=def aria-labelledby=ariaRowIndex>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -7835,7 +7835,7 @@
   </tbody>
 </table>
 <h4 id=ariaRowIndexText><code>aria-rowindextext</code></h4>
-<table aria-labelledby=ariaRowIndexText>
+<table class=def aria-labelledby=ariaRowIndexText>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -7870,7 +7870,7 @@
   </tbody>
 </table>
 <h4 id=ariaRowSpan><code>aria-rowspan</code></h4>
-<table aria-labelledby=ariaRowSpan>
+<table class=def aria-labelledby=ariaRowSpan>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -7907,7 +7907,7 @@
   </tbody>
 </table>
 <h4 id=ariaSelectedTrue><code>aria-selected</code>=<code>true</code></h4>
-<table aria-labelledby=ariaSelectedTrue>
+<table class=def aria-labelledby=ariaSelectedTrue>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -7946,7 +7946,7 @@
   </tbody>
 </table>
 <h4 id=ariaSelectedFalse><code>aria-selected</code>=<code>false</code></h4>
-<table aria-labelledby=ariaSelectedFalse>
+<table class=def aria-labelledby=ariaSelectedFalse>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -7985,7 +7985,7 @@
   </tbody>
 </table>
 <h4 id=ariaSelectedUndefined><code>aria-selected</code> is undefined</h4>
-<table aria-labelledby=ariaSelectedUndefined>
+<table class=def aria-labelledby=ariaSelectedUndefined>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -8020,7 +8020,7 @@
   </tbody>
 </table>
 <h4 id=ariaSetsize><code>aria-setsize</code></h4>
-<table aria-labelledby=ariaSetsize>
+<table class=def aria-labelledby=ariaSetsize>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -8061,7 +8061,7 @@
   </tbody>
 </table>
 <h4 id=ariaSortAscending><code>aria-sort</code>=<code>ascending</code></h4>
-<table aria-labelledby=ariaSortAscending>
+<table class=def aria-labelledby=ariaSortAscending>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -8097,7 +8097,7 @@
   </tbody>
 </table>
 <h4 id=ariaSortDescending><code>aria-sort</code>=<code>descending</code></h4>
-<table aria-labelledby=ariaSortDescending>
+<table class=def aria-labelledby=ariaSortDescending>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -8133,7 +8133,7 @@
   </tbody>
 </table>
 <h4 id=ariaSortOther><code>aria-sort</code>=<code>other</code></h4>
-<table aria-labelledby=ariaSortOther>
+<table class=def aria-labelledby=ariaSortOther>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -8169,7 +8169,7 @@
   </tbody>
 </table>
 <h4 id=ariaSortNone><code>aria-sort</code>=<code>none</code></h4>
-<table aria-labelledby=ariaSortNone>
+<table class=def aria-labelledby=ariaSortNone>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -8204,7 +8204,7 @@
   </tbody>
 </table>
 <h4 id=ariaValueMax><code>aria-valuemax</code></h4>
-<table aria-labelledby=ariaValueMax>
+<table class=def aria-labelledby=ariaValueMax>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -8243,7 +8243,7 @@
   </tbody>
 </table>
 <h4 id=ariaValueMin><code>aria-valuemin</code></h4>
-<table aria-labelledby=ariaValueMin>
+<table class=def aria-labelledby=ariaValueMin>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -8282,7 +8282,7 @@
   </tbody>
 </table>
 <h4 id=ariaValueNow><code>aria-valuenow</code></h4>
-<table aria-labelledby=ariaValueNow>
+<table class=def aria-labelledby=ariaValueNow>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -8322,7 +8322,7 @@
   </tbody>
 </table>
 <h4 id=ariaValueText><code>aria-valuetext</code></h4>
-<table aria-labelledby=ariaValueText>
+<table class=def aria-labelledby=ariaValueText>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -8433,7 +8433,7 @@
         <p>For simplicity and  performance the user agent MAY trim out change events for state or property changes that <a class="termref">assistive technologies</a> typically ignore, such as events that are happening in a window that does not currently have focus.        </p>
         <p class="note">Translators: For label text associated with the following table and its toggle buttons, see the <code>mappingTableLabels</code> object in the <code>&lt;head&gt;</code> section of this document.</p>
 <h4 id=event-aria-activedescendant><code>aria-activedescendant</code></h4>
-<table aria-labelledby=event-aria-activedescendant>
+<table class=def aria-labelledby=event-aria-activedescendant>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -8474,7 +8474,7 @@
   </tbody>
 </table>
 <h4 id=event-aria-busy><code>aria-busy</code> (state)</h4>
-<table aria-labelledby=event-aria-busy>
+<table class=def aria-labelledby=event-aria-busy>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -8510,7 +8510,7 @@
   </tbody>
 </table>
 <h4 id=event-aria-checked><code>aria-checked</code> (state)</h4>
-<table aria-labelledby=event-aria-checked>
+<table class=def aria-labelledby=event-aria-checked>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -8546,7 +8546,7 @@
   </tbody>
 </table>
 <h4 id=event-aria-current><code>aria-current</code> (state)</h4>
-<table aria-labelledby=event-aria-current>
+<table class=def aria-labelledby=event-aria-current>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -8582,7 +8582,7 @@
   </tbody>
 </table>
 <h4 id=event-aria-disabled><code>aria-disabled</code> (state)</h4>
-<table aria-labelledby=event-aria-disabled>
+<table class=def aria-labelledby=event-aria-disabled>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -8618,7 +8618,7 @@
   </tbody>
 </table>
 <h4 id=event-aria-describedby><code>aria-describedby</code></h4>
-<table aria-labelledby=event-aria-describedby>
+<table class=def aria-labelledby=event-aria-describedby>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -8654,7 +8654,7 @@
   </tbody>
 </table>
 <h4 id=event-aria-dropeffect><code>aria-dropeffect</code> (property)</h4>
-<table aria-labelledby=event-aria-dropeffect>
+<table class=def aria-labelledby=event-aria-dropeffect>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -8690,7 +8690,7 @@
   </tbody>
 </table>
 <h4 id=event-aria-expanded><code>aria-expanded</code> (state)</h4>
-<table aria-labelledby=event-aria-expanded>
+<table class=def aria-labelledby=event-aria-expanded>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -8728,7 +8728,7 @@
   </tbody>
 </table>
 <h4 id=event-aria-grabbed><code>aria-grabbed</code> (state)</h4>
-<table aria-labelledby=event-aria-grabbed>
+<table class=def aria-labelledby=event-aria-grabbed>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -8765,7 +8765,7 @@
   </tbody>
 </table>
 <h4 id=event-aria-hidden><code>aria-hidden</code> (state)</h4>
-<table aria-labelledby=event-aria-hidden>
+<table class=def aria-labelledby=event-aria-hidden>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -8803,7 +8803,7 @@
   </tbody>
 </table>
 <h4 id=event-aria-invalid><code>aria-invalid</code> (state)</h4>
-<table aria-labelledby=event-aria-invalid>
+<table class=def aria-labelledby=event-aria-invalid>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -8839,7 +8839,7 @@
   </tbody>
 </table>
 <h4 id=event-aria-label><code>aria-label</code> and <code>aria-labelledby</code></h4>
-<table aria-labelledby=event-aria-label>
+<table class=def aria-labelledby=event-aria-label>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -8876,7 +8876,7 @@
   </tbody>
 </table>
 <h4 id=event-aria-pressed><code>aria-pressed</code> (state)</h4>
-<table aria-labelledby=event-aria-pressed>
+<table class=def aria-labelledby=event-aria-pressed>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -8912,7 +8912,7 @@
   </tbody>
 </table>
 <h4 id=event-aria-readonly><code>aria-readonly</code></h4>
-<table aria-labelledby=event-aria-readonly>
+<table class=def aria-labelledby=event-aria-readonly>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -8948,7 +8948,7 @@
   </tbody>
 </table>
 <h4 id=event-aria-required><code>aria-required</code></h4>
-<table aria-labelledby=event-aria-required>
+<table class=def aria-labelledby=event-aria-required>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -8984,7 +8984,7 @@
   </tbody>
 </table>
 <h4 id=event-aria-selected><code>aria-selected</code> (state)</h4>
-<table aria-labelledby=event-aria-selected>
+<table class=def aria-labelledby=event-aria-selected>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -9019,7 +9019,7 @@
   </tbody>
 </table>
 <h4 id=event-aria-valuenow><code>aria-valuenow</code></h4>
-<table aria-labelledby=event-aria-valuenow>
+<table class=def aria-labelledby=event-aria-valuenow>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -9055,7 +9055,7 @@
   </tbody>
 </table>
 <h4 id=event-aria-valuetext><code>aria-valuetext</code></h4>
-<table aria-labelledby=event-aria-valuetext>
+<table class=def aria-labelledby=event-aria-valuetext>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
@@ -9094,7 +9094,7 @@
     <section id="mapping_events_visibility">
 		  <h3>Changes to document content or node visibility</h3>
 		  <p>Processing document changes is important regardless of <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr>. The events described in the table below are used by user agents to inform <abbr title="assistive technology">AT</abbr> of changes to the <abbr title="Document Object Model">DOM</abbr> via the accessibility tree. For the purposes of conformance with this standard, [=user agents=]  MUST implement the behavior described in this section whenever <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> attributes are applied to dynamic content on a Web page.        </p>
-		  <table>
+		  <table class=def>
           <caption>Table of document change scenarios and events to be fired in each <abbr title="application programming interface">API</abbr></caption>
           <tbody>
             <tr>
@@ -9128,7 +9128,7 @@
           </tbody>
         </table>
 		<p>Fire these events for node changes where the node in question is an element and has an <a class="termref">accessible object</a>:</p>
-        <table>
+        <table class=def>
           <caption>Table of document change scenarios and events to be fired in each <abbr title="application programming interface">API</abbr></caption>
           <tbody>
             <tr>
@@ -9214,7 +9214,7 @@
     <section id="focus_state_event_table">
       <h3>Focus Changes</h3>
       <p>The following table defines the accessibility <abbr title="Application Programming Interface">API</abbr> keyboard focus states and events.</p>
-      <table>
+      <table class=def>
 	<caption>Table of <a class="termref">accessibility <abbr title="application programming interface">APIs</abbr></a> for focus states and <a class="termref">events</a></caption>
 	<tr>
 	  <th>&#160;</th>
@@ -9259,7 +9259,7 @@
 			  <li>Multiple selection</li>
 		  </ul>
       <p>In the single selection case, selection follows focus (see the section "<a href="#focus_state_event_table">Focus States and Events Table</a>" for information about focus events). User agents MUST fire the following events when <a class="state-reference" href="#aria-selected"><code>aria-selected</code></a> changes:</p>
-      <table>
+      <table class=def>
         <caption>Single selection events</caption>
 	      <tbody>
 				<tr>
@@ -9295,7 +9295,7 @@
 			<li>In Microsoft <abbr title="User Interface Automation">UIA</abbr>, the <code>Selection</code> and <code>SelectionItem</code> Control Patterns expose the selection availability, state, and methods.</li>
 			<li>User agents MUST fire the following events when <a class="state-reference" href="#aria-selected"><code>aria-selected</code></a> changes on a descendant, as follows:</li>
 		</ol>
-		<table>
+		<table class=def>
 		  <caption>Multiple selection events</caption>
       <tbody>
 				<tr>
@@ -9363,7 +9363,7 @@
 	    <h3>Special Events for Menus</h3>
 		  <p>Some <abbr title="Application Programming Interfaces">APIs</abbr>, provide special <a class="termref">events</a> whenever a menu is opened or closed.  [=User agents=]  SHOULD provide the events as described in the table below.  If provided, because menus can be made visible or [=element/hidden=] using a variety of techniques, a [=user agent=]  MUST ensure that the events are nested and symmetrical. </p>
 		  <p>Frequently, a <a class="role-reference" href="#menubar"><code>menubar</code></a> is used to organize a hierarchy of menus.  In those cases, the menubar MUST be a <abbr title="Document Object Model">DOM</abbr> parent of the associated <a class="role-reference" href="#menuitem"><code>menuitem</code></a>s, or one defined by <a class="property-reference" href="#aria-owns"><code>aria-owns</code></a>.  In other cases, no menubar is involved; for example, when the <a class="role-reference" href="#menu"><code>menu</code></a> is associated with a toolbar button, or is a context menu. Nonetheless the relevant menu events are provided as described in the following table. </p>
-     <table>
+     <table class=def>
       <caption>Menu events</caption>
 			<tbody>
 				<tr>


### PR DESCRIPTION
whaddya think @scottaohara @jnurthen @pkra ?

Trying to get rid of custom CSS - this uses [respec CSS for def tables](https://www.w3.org/StyleSheets/TR/2021/README#def)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/pull/193.html" title="Last updated on Sep 13, 2023, 4:01 PM UTC (088303d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/193/304b450...088303d.html" title="Last updated on Sep 13, 2023, 4:01 PM UTC (088303d)">Diff</a>