### PR TITLE
Make haspopup='true' mapping identical to haspopup='menu'

### DIFF
--- a/index.html
+++ b/index.html
@@ -6076,7 +6076,7 @@
       <th>MSAA + IAccessible2 </th>
       <td>
         <span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span><br>
-        <span class="property">Object Attribute: <code>haspopup:true</code></span>
+        <span class="property">Object Attribute: <code>haspopup:menu</code></span>
       </td>
     </tr>
     <tr>
@@ -6090,7 +6090,7 @@
       <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
       <td>
         <span class="property">State: <code>STATE_HAS_POPUP</code></span><br>
-        <span class="property">Object Attribute: <code>haspopup:true</code></span>
+        <span class="property">Object Attribute: <code>haspopup:menu</code></span>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Closes #189 

This change only affects IA2 and ATK/AT-SPI.

* [WPT tests](https://github.com/web-platform-tests/wpt/pull/42011)
* Implementations (link to issue or when done, link to commit):
   * WebKit: N/A
   * Gecko: [Gecko bug report](https://bugzilla.mozilla.org/show_bug.cgi?id=1850465)
   * Blink: Behavior matches this change.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sivakusayan/core-aam/pull/194.html" title="Last updated on Sep 18, 2023, 12:19 AM UTC (2a6b382)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/194/304b450...sivakusayan:2a6b382.html" title="Last updated on Sep 18, 2023, 12:19 AM UTC (2a6b382)">Diff</a>