### PR TITLE
core-aam is confidently wrong about a lot of AX notifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -8576,7 +8576,7 @@
     <tr>
       <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
       <td>
-        No notification
+        <code>AXCurrentStateChanged</code>
       </td>
     </tr>
   </tbody>
@@ -8612,7 +8612,7 @@
     <tr>
       <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
       <td>
-        No notification
+        <code>AXDisabledStateChanged</code>
       </td>
     </tr>
   </tbody>
@@ -8648,18 +8648,18 @@
     <tr>
       <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
       <td>
-        TBD
+        <code>AXDescribedByChanged</code>
       </td>
     </tr>
   </tbody>
 </table>
-<h4 id=event-aria-dropeffect><code>aria-dropeffect</code> (property)</h4>
+<h4 id=event-aria-dropeffect><code>aria-dropeffect</code> (property, deprecated)</h4>
 <table aria-labelledby=event-aria-dropeffect>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
       <td>
-        <a class="property-reference" href="#aria-dropeffect"><code>aria-dropeffect</code></a> (property)
+        <a class="property-reference" href="#aria-dropeffect"><code>aria-dropeffect</code></a> (property, deprecated)
       </td>
     </tr>
     <tr>
@@ -8684,7 +8684,7 @@
     <tr>
       <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
       <td>
-        No notification
+        <code>AXDropEffectChanged</code>
       </td>
     </tr>
   </tbody>
@@ -8727,13 +8727,13 @@
     </tr>
   </tbody>
 </table>
-<h4 id=event-aria-grabbed><code>aria-grabbed</code> (state)</h4>
+<h4 id=event-aria-grabbed><code>aria-grabbed</code> (state, deprecated)</h4>
 <table aria-labelledby=event-aria-grabbed>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
       <td>
-        <a class="state-reference" href="#aria-grabbed"><code>aria-grabbed</code></a> (state)
+        <a class="state-reference" href="#aria-grabbed"><code>aria-grabbed</code></a> (state, deprecated)
       </td>
     </tr>
     <tr>
@@ -8759,7 +8759,7 @@
     <tr>
       <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
       <td>
-        No notification
+        <code>AXGrabbedStateChanged</code>
       </td>
     </tr>
   </tbody>
@@ -8870,7 +8870,7 @@
     <tr>
       <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
       <td>
-        TBD
+        <code>AXLabelCreated</code>
       </td>
     </tr>
   </tbody>
@@ -8906,7 +8906,7 @@
     <tr>
       <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
       <td>
-        No notification
+        <code>AXPressedStateChanged</code>
       </td>
     </tr>
   </tbody>
@@ -8942,7 +8942,7 @@
     <tr>
       <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
       <td>
-        No notification
+        <code>AXReadOnlyStatusChanged</code>
       </td>
     </tr>
   </tbody>
@@ -8978,7 +8978,7 @@
     <tr>
       <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
       <td>
-        No notification
+        <code>AXRequiredStatusChanged</code>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
notification updates.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/pull/201.html" title="Last updated on Oct 16, 2023, 5:15 AM UTC (4b04674)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/201/36a2644...4b04674.html" title="Last updated on Oct 16, 2023, 5:15 AM UTC (4b04674)">Diff</a>