### PR TITLE
Add aria-haspopup='grid' mappings

### DIFF
--- a/index.html
+++ b/index.html
@@ -6177,6 +6177,45 @@
     </tr>
   </tbody>
 </table>
+<h4 id=ariaHaspopupGrid><code>aria-haspopup</code>=<code>grid</code></h4>
+<table aria-labelledby=ariaHaspopupGrid>
+  <tbody>
+    <tr>
+      <th>ARIA Specification</th>
+      <td>
+        <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a>=<code>grid</code>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 </th>
+      <td>
+        <span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span><br>
+        <span class="property">Object Attribute: <code>haspopup:grid</code></span>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr></th>
+      <td>
+        <span class="property">Control Pattern: <code>ExpandCollapse</code></span><br>
+        <span class="seealso">See also: <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a></span>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+      <td>
+        <span class="property">State: <code>STATE_HAS_POPUP</code></span><br>
+        <span class="property">Object Attribute: <code>haspopup:grid</code></span>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+      <td>
+        <span class="property">Property: <code>AXPopupValue:grid</code></span><br>
+        <span class="action">Action: <code>AXShowMenu</code></span>
+      </td>
+    </tr>
+  </tbody>
+</table>
 <h4 id=ariaHaspopupListbox><code>aria-haspopup</code>=<code>listbox</code></h4>
 <table aria-labelledby=ariaHaspopupListbox>
   <tbody>


### PR DESCRIPTION
Closes #190 

I think this is straightforward - we're just copy-pasting the other `aria-haspopup` mappings and tweaking the value.

* [WPT tests](https://github.com/web-platform-tests/wpt/pull/42549)
* Implementations:
   * [WebKit AX mapping](https://github.com/WebKit/WebKit/blob/066a9fc870b06ca5eed91af3c7ad170e253242af/Source/WebCore/accessibility/AccessibilityObject.cpp#L3282)
   * Gecko:
      * [Gecko IA2/ATK mapping](https://searchfox.org/mozilla-central/source/accessible/base/ARIAStateMap.cpp#158) probably? 
      * [Gecko AX mapping ](https://searchfox.org/mozilla-central/source/accessible/mac/mozActionElements.mm#27)
   * Blink:
      * [Blink IA2/ATK mapping](https://github.com/chromium/chromium/blob/78f6e36bd96ebe7ceb38d754c75e6d92613ebdb7/ui/accessibility/platform/ax_platform_node_base.cc#L1376)
      * [Blink UIA mapping](https://github.com/chromium/chromium/blob/78f6e36bd96ebe7ceb38d754c75e6d92613ebdb7/ui/accessibility/platform/ax_platform_node_win.cc#L7249)
      * [Blink AX mapping](https://github.com/chromium/chromium/blob/78f6e36bd96ebe7ceb38d754c75e6d92613ebdb7/ui/accessibility/platform/ax_platform_node_cocoa.mm#L1747)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sivakusayan/core-aam/pull/202.html" title="Last updated on Oct 16, 2023, 5:32 AM UTC (9ea9607)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/202/36a2644...sivakusayan:9ea9607.html" title="Last updated on Oct 16, 2023, 5:32 AM UTC (9ea9607)">Diff</a>