### PR TITLE
Remove UIA_DescribedBy property from aria-describedby UIA mappings

### DIFF
--- a/index.html
+++ b/index.html
@@ -5530,7 +5530,6 @@
       <th><abbr title="User Interface Automation">UIA</abbr></th>
       <td>
         <span class="property">Property: <code>FullDescription</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="property">Property: <code>DescribedBy</code>: points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br>
         <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
       </td>
     </tr>


### PR DESCRIPTION
Closes #204 

The UIA_DescribedBy property actually maps more closely to the definition of aria-details than it does the one of aria-describedby. In this PR, we remove any mention of the UIA_DescribedBy property in the UIA mappings of the aria-describedby attribute.

Chromium will fully reflect this updated mapping (and the current UIA mapping of aria-details) as soon as https://chromium-review.googlesource.com/c/chromium/src/+/4935457 merges.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/pull/205.html" title="Last updated on Oct 20, 2023, 9:57 PM UTC (08a0604)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/205/36a2644...08a0604.html" title="Last updated on Oct 20, 2023, 9:57 PM UTC (08a0604)">Diff</a>