### PR TITLE
Fix computed role typo for role radiogroup

### DIFF
--- a/index.html
+++ b/index.html
@@ -3130,7 +3130,7 @@
     <tr>
       <th>Computed Role</th>
       <td>
-        <p><code>ragiogroup</code></p>
+        <p><code>radiogroup</code></p>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Fixes a minor typo in the [computed role for 4.4.3.62 radiogroup](https://www.w3.org/TR/core-aam-1.2/#role-map-radiogroup), `ragiogroup` -> `radiogroup`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/pull/208.html" title="Last updated on Oct 30, 2023, 5:22 AM UTC (276f55a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/208/8def608...276f55a.html" title="Last updated on Oct 30, 2023, 5:22 AM UTC (276f55a)">Diff</a>