### PR TITLE
Editorial: user agent does not mean assistive technology

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,10 +210,10 @@
 	  </section>
   <section>
       <h4>Comparing Accessibility APIs</h4>
-      <p>For various technological and historical reasons, accessibility APIs do not all work in the same way. In many cases, there is no simple one-to-one relationship between how each of them names or exposes roles, states, and properties to user agents. The following subsections describe a few of the distinguishing characteristics of some of the APIs.</p>
+      <p>For various technological and historical reasons, accessibility APIs do not all work in the same way. In many cases, there is no simple one-to-one relationship between how each of them names or exposes roles, states, and properties to assistive technologies. The following subsections describe a few of the distinguishing characteristics of some of the APIs.</p>
       <section>
         <h5>ATK/AT-SPI</h5>
-        <p>MSAA, IAccessible2, UIA, and AX API each define an API that is shared by both the software application exposing information about its content and interactive components, and the user agent (assistive technology) consuming that information. Conversely, Linux/GNOME separates that shared interface into its two aspects, each represented by a different accessibility API: ATK or AT-SPI.</p>
+        <p>MSAA, IAccessible2, UIA, and AX API each define an API that is shared by both the software application exposing information about its content and interactive components, and the assistive technology consuming that information. Conversely, Linux/GNOME separates that shared interface into its two aspects, each represented by a different accessibility API: ATK or AT-SPI.</p>
         <p>ATK defines an interface that is implemented by software in order to expose accessibility information, whereas AT-SPI is a desktop service that gathers accessibility information from active applications and relays it to other interested applications, usually assistive technologies.</p>
         <p>For example, the GNOME GUI toolkit [GTK], implements the relevant aspects of ATK for each widget (menu, combobox, checkbox, etc.) in order that GTK widgets expose accessibility information about themselves. AT-SPI then acquires the information from applications built with GTK and makes it available to interested parties.</p>
         <p>ATK is most relevant to implementors, whereas AT-SPI is relevant to consumers. In the context of mapping WAI-ARIA roles, states and properties, user agents are implementors and use ATK. Assistive Technologies are consumers, and use AT-SPI.</p>


### PR DESCRIPTION
Closes #200

After an audit, this seems to be the only two places where user agent is used in this incorrect way.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/pull/210.html" title="Last updated on Oct 31, 2023, 7:54 PM UTC (8a8df8c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/210/e523bb9...8a8df8c.html" title="Last updated on Oct 31, 2023, 7:54 PM UTC (8a8df8c)">Diff</a>