### PR TITLE
editorial: adjust contributors section

### DIFF
--- a/index.html
+++ b/index.html
@@ -9502,8 +9502,10 @@
 	<section class="appendix informative section" id="acknowledgements">
 		<h3>Acknowledgments</h3>
 		<p>The following people contributed to the development of this document.</p>
+		<ul id="gh-contributors">
+			<!-- list of contributors will appear here, along with link to their GitHub profiles -->
+		</ul>
 		<div data-include="common/acknowledgements/aria-wg-active.html" data-include-replace="true"></div>
-		<div data-include="common/acknowledgements/aria-contributors.html" data-include-replace="true"></div>
 		<div data-include="common/acknowledgements/funders.html" data-include-replace="true"></div>
 	</section>
 </body>


### PR DESCRIPTION
Drops the previously active section and adds a new GH contributors section, matching other ARIA specs.

See https://github.com/w3c/aria-common/issues/103 for more background.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/pull/211.html" title="Last updated on Nov 10, 2023, 1:15 PM UTC (2d2d8df)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/211/4701d18...2d2d8df.html" title="Last updated on Nov 10, 2023, 1:15 PM UTC (2d2d8df)">Diff</a>