### PR TITLE
Editorial: Remove reference to no longer existing term (owned)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2779,25 +2779,25 @@
     <tr>
       <th>MSAA + IAccessible2</th>
       <td>
-        <p>For objects that have required accessibility children (e.g., a grid requires gridcell children, a list requires listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>IA2_ROLE_TEXT_FRAME</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
+        <p>For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>IA2_ROLE_TEXT_FRAME</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
       </td>
     </tr>
     <tr>
       <th><abbr title="User Interface Automation">UIA</abbr></th>
       <td>
-        <p>For objects that have required accessibility children (e.g., a grid requires gridcell children, a list requires listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it using the <code>text</code> pattern. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
+        <p>For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it using the <code>text</code> pattern. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
       </td>
     </tr>
     <tr>
       <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
       <td>
-        <p>For objects that have required accessibility children (e.g., a grid requires gridcell children, a list requires listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>ROLE_SECTION</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
+        <p>For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>ROLE_SECTION</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
       </td>
     </tr>
     <tr>
       <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
       <td>
-        <p>For objects that have required accessibility children (e.g., a grid requires gridcell children, a list requires listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>AXGroup</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
+        <p>For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>AXGroup</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
       </td>
     </tr>
   </tbody>
@@ -3000,25 +3000,25 @@
     <tr>
       <th>MSAA + IAccessible2</th>
       <td>
-        <p>For objects that have required accessibility children (e.g., a grid requires gridcell children, a list requires listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>IA2_ROLE_TEXT_FRAME</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
+        <p>For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>IA2_ROLE_TEXT_FRAME</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
       </td>
     </tr>
     <tr>
       <th><abbr title="User Interface Automation">UIA</abbr></th>
       <td>
-        <p>For objects that have required accessibility children (e.g., a grid requires gridcell children, a list requires listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it using the <code>text</code> pattern. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
+        <p>For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it using the <code>text</code> pattern. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
       </td>
     </tr>
     <tr>
       <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
       <td>
-        <p>For objects that have required accessibility children (e.g., a grid requires gridcell children, a list requires listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>ROLE_SECTION</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
+        <p>For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>ROLE_SECTION</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
       </td>
     </tr>
     <tr>
       <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
       <td>
-        <p>For objects that have required accessibility children (e.g., a grid requires gridcell children, a list requires listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>AXGroup</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
+        <p>For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>AXGroup</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
       </td>
     </tr>
   </tbody>

--- a/index.html
+++ b/index.html
@@ -291,7 +291,7 @@
 	<section id="mapping_conflicts">
 		<h3>Conflicts between native markup semantics and <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr></h3>
 		  <p><abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr>  roles, states, and properties are intended to add <a class="termref">semantic</a> information when native host language <a class="termref">elements</a> with these semantics are not available, and are generally used on elements that have no native semantics of their own. They can also be used on elements that have similar but not identical semantics to the intended object (for instance, a nested list could be used to represent a tree structure). This method can be  part of a fallback strategy for older browsers that have no <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> implementation, or because native presentation of the repurposed element reduces the amount of style and/or script needed. Except for the cases outlined below, [=user agents=] MUST always use the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> semantics to define how it exposes the element to <a class="termref">accessibility APIs</a>, rather than using the host language semantics.</p>
-		  <p>Host languages can have features that have implicit <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> semantics corresponding to <a class="termref">roles</a>. When a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role is provided that has a corresponding role in the accessibility <abbr title="Application Programming Interface">API</abbr>, user agents MUST use the semantic of the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role for processing, not the native semantic, unless the role requires <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> states and properties whose attributes are explicitly forbidden on the native element by the host language.  Values for roles do not conflict in the same way as values for states and properties, and because authors are expected to have a valid reason to provide a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role even on elements that would not normally be repurposed. For example, spin buttons are typically constructed from text fields (<code>&lt;input  type=&quot;text&quot;&gt;</code>) in order to get most of the default keyboard support.  But, the native role, &quot;text field&quot;, is not correct because it does not properly communicate the additional features of a spin button.  The author adds the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role of <code>spinbutton</code> (<code>&lt;input type=&quot;text&quot; role=&quot;spinbutton&quot; ...&gt;</code>) so that the control is properly mapped in the accessibility <abbr title="Application Programming Interface">API</abbr>. When a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role is provided that does not have a corresponding role in the accessibility <abbr title="Application Programming Interface">API</abbr>, user agents MAY expose the native semantic in addition to the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role. If the host language element is overridden by a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role whose semantics or structure is not equivalent to the native host language semantics or to a subclass of those semantics, then treat any required [=ARIA/owned=] elements of the native role as having role <a href="#role-map-presentation">presentation</a> or <a href="#role-map-none">none</a>.</p>
+		  <p>Host languages can have features that have implicit <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> semantics corresponding to <a class="termref">roles</a>. When a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role is provided that has a corresponding role in the accessibility <abbr title="Application Programming Interface">API</abbr>, user agents MUST use the semantic of the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role for processing, not the native semantic, unless the role requires <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> states and properties whose attributes are explicitly forbidden on the native element by the host language.  Values for roles do not conflict in the same way as values for states and properties, and because authors are expected to have a valid reason to provide a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role even on elements that would not normally be repurposed. For example, spin buttons are typically constructed from text fields (<code>&lt;input  type=&quot;text&quot;&gt;</code>) in order to get most of the default keyboard support.  But, the native role, &quot;text field&quot;, is not correct because it does not properly communicate the additional features of a spin button.  The author adds the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role of <code>spinbutton</code> (<code>&lt;input type=&quot;text&quot; role=&quot;spinbutton&quot; ...&gt;</code>) so that the control is properly mapped in the accessibility <abbr title="Application Programming Interface">API</abbr>. When a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role is provided that does not have a corresponding role in the accessibility <abbr title="Application Programming Interface">API</abbr>, user agents MAY expose the native semantic in addition to the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role. If the host language element is overridden by a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role whose semantics or structure is not equivalent to the native host language semantics or to a subclass of those semantics, then treat any child elements having roles specified as Allowed Accessibility Child Roles as having <a href="#role-map-presentation">presentation</a> or <a href="#role-map-none">none</a>.</p>
 		  <p class="note">The above text differs slightly from the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> specification. The requirement for user agents to expose the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role instead of the native role was intended to only apply in cases where there is a direct mapping from the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role to a corresponding role in the accessibility <abbr title="Application Programming Interface">API</abbr>. The wording of the requirement is not clear in the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> specification, however, and has been interpreted differently by implementers. The requirement has been clarified here and an additional statement added to indicate that user agents may expose native semantics if there is not a direct mapping to a role in the accessibility <abbr title="Application Programming Interface">API</abbr>. Because there are differing implementations, authors will be advised against adding such <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> roles to native elements that have their own semantics in the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Authoring Practices Guide.</p>
       <p>When <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> states and properties correspond to host language features that have the same implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantic, it can be problematic if the values become out of sync. For example, the <abbr title="Hypertext Markup Language">HTML</abbr> <code>checked</code> attribute and the <code>aria-checked</code> attribute could have conflicting values. Therefore to prevent providing conflicting states and properties to assistive technologies, host languages will explicitly declare where the use of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> attributes on a host language element conflict with native attributes for that element. When a host language declares a <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a class="termref">attribute</a> to be in direct semantic conflict with a native attribute for a given element, user agents MUST ignore the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> attribute and instead use the host language attribute with the same implicit semantic. </p>
       <p>Host languages might also document features that cannot be overridden with <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> (these are called &quot;strong native semantics&quot;). These can be features that have implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics as well as features where the processing would be uncertain if the semantics were changed with <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>. While conformance checkers might signal an error or warning when a <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role is used on elements with strong native semantics, user agents MUST still use the value of the semantic of the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role when exposing the element to accessibility <abbr title="Application Programming Interfaces">APIs</abbr>.</p>
@@ -2064,13 +2064,13 @@
     </tr>
   </tbody>
 </table>
-<h4 id=role-map-listbox><code>listbox</code> not owned by or child of <code>combobox</code></h4>
+<h4 id=role-map-listbox><code>listbox</code> without an accessibility parent of <code>combobox</code></h4>
 <table aria-labelledby=role-map-listbox>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
       <td>
-        <a class="role-reference" href="#listbox"><code>listbox</code></a> not owned by or child of <code>combobox</code>
+        <a class="role-reference" href="#listbox"><code>listbox</code></a>
       </td>
     </tr>
     <tr>
@@ -2111,13 +2111,13 @@
     </tr>
   </tbody>
 </table>
-<h4 id=role-map-listbox-in-combobox><code>listbox</code> owned by or child of <code>combobox</code></h4>
+<h4 id=role-map-listbox-in-combobox><code>listbox</code> with an accessibility parent of <code>combobox</code></h4>
 <table aria-labelledby=role-map-listbox-in-combobox>
   <tbody>
     <tr>
       <th>ARIA Specification</th>
       <td>
-        <a class="role-reference" href="#listbox"><code>listbox</code></a> owned by or child of <code>combobox</code>
+        <a class="role-reference" href="#listbox"><code>listbox</code></a>
       </td>
     </tr>
     <tr>
@@ -2779,25 +2779,25 @@
     <tr>
       <th>MSAA + IAccessible2</th>
       <td>
-        <p>For objects that have required owned descendants (e.g., a grid owns gridcells, a list owns listitems), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>IA2_ROLE_TEXT_FRAME</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
+        <p>For objects that have required accessibility children (e.g., a grid requires gridcell children, a list requires listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>IA2_ROLE_TEXT_FRAME</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
       </td>
     </tr>
     <tr>
       <th><abbr title="User Interface Automation">UIA</abbr></th>
       <td>
-        <p>For objects that have required owned descendants (e.g., a grid owns gridcells, a list owns listitems), and the descendant is in the <a class="termref">accessibility tree</a>, expose it using the <code>text</code> pattern. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
+        <p>For objects that have required accessibility children (e.g., a grid requires gridcell children, a list requires listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it using the <code>text</code> pattern. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
       </td>
     </tr>
     <tr>
       <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
       <td>
-        <p>For objects that have required owned descendants (e.g., a grid owns gridcells, a list owns listitems), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>ROLE_SECTION</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
+        <p>For objects that have required accessibility children (e.g., a grid requires gridcell children, a list requires listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>ROLE_SECTION</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
       </td>
     </tr>
     <tr>
       <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
       <td>
-        <p>For objects that have required owned descendants (e.g., a grid owns gridcells, a list owns listitems), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>AXGroup</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
+        <p>For objects that have required accessibility children (e.g., a grid requires gridcell children, a list requires listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>AXGroup</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
       </td>
     </tr>
   </tbody>
@@ -3000,25 +3000,25 @@
     <tr>
       <th>MSAA + IAccessible2</th>
       <td>
-        <p>For objects that have required owned descendants (e.g., a grid owns gridcells, a list owns listitems), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>IA2_ROLE_TEXT_FRAME</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
+        <p>For objects that have required accessibility children (e.g., a grid requires gridcell children, a list requires listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>IA2_ROLE_TEXT_FRAME</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
       </td>
     </tr>
     <tr>
       <th><abbr title="User Interface Automation">UIA</abbr></th>
       <td>
-        <p>For objects that have required owned descendants (e.g., a grid owns gridcells, a list owns listitems), and the descendant is in the <a class="termref">accessibility tree</a>, expose it using the <code>text</code> pattern. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
+        <p>For objects that have required accessibility children (e.g., a grid requires gridcell children, a list requires listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it using the <code>text</code> pattern. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
       </td>
     </tr>
     <tr>
       <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
       <td>
-        <p>For objects that have required owned descendants (e.g., a grid owns gridcells, a list owns listitems), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>ROLE_SECTION</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
+        <p>For objects that have required accessibility children (e.g., a grid requires gridcell children, a list requires listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>ROLE_SECTION</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
       </td>
     </tr>
     <tr>
       <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
       <td>
-        <p>For objects that have required owned descendants (e.g., a grid owns gridcells, a list owns listitems), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>AXGroup</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
+        <p>For objects that have required accessibility children (e.g., a grid requires gridcell children, a list requires listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>AXGroup</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
We no longer have "required owned elements", etc, in the ARIA spec, instead we have:
- [allowed accessibility children](https://w3c.github.io/aria/#mustContain)
- [required accessibility parent](https://w3c.github.io/aria/#scope)

And "owned"/"owns" has been replace with tree language defined here: 
- [Relationships in the Accessibility Tree](https://w3c.github.io/aria/#tree_relationships)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/pull/214.html" title="Last updated on Feb 12, 2024, 8:32 PM UTC (cead19b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/214/da44641...cead19b.html" title="Last updated on Feb 12, 2024, 8:32 PM UTC (cead19b)">Diff</a>