### PR TITLE
Update: UIA mappings for elements that had control type text

### DIFF
--- a/index.html
+++ b/index.html
@@ -781,7 +781,8 @@
     <tr>
       <th><abbr title="User Interface Automation">UIA</abbr></th>
       <td>
-        <span class="property">Control Type: <code>Text</code></span>
+        <span class="property">Control Type: <code>Group</code></span>
+	<span class="property">Localized Control Type: <code>caption</code></span>
       </td>
     </tr>
     <tr>
@@ -917,7 +918,7 @@
     <tr>
       <th><abbr title="User Interface Automation">UIA</abbr></th>
       <td>
-        <span class="property">Control Type: <code>Text</code></span><br>
+        <span class="property">Control Type: <code>Group</code></span><br>
         <span class="property">Localized Control Type: <code>code</code></span>
       </td>
     </tr>
@@ -1236,7 +1237,7 @@
     <tr>
       <th><abbr title="User Interface Automation">UIA</abbr></th>
       <td>
-        <span class="property">Control Type: <code>Text</code></span><br>
+        <span class="property">Control Type: <code>Group</code></span><br>
         <span class="property">Localized Control Type: <code>deletion</code></span>
       </td>
     </tr>
@@ -1822,7 +1823,7 @@
     <tr>
       <th><abbr title="User Interface Automation">UIA</abbr></th>
       <td>
-        <span class="property">Control Type: <code>Text</code></span><br>
+        <span class="property">Control Type: <code>Group</code></span><br>
         <span class="property">Localized Control Type: <code>heading</code></span>
       </td>
     </tr>
@@ -2964,7 +2965,7 @@
     <tr>
       <th><abbr title="User Interface Automation">UIA</abbr></th>
       <td>
-        <span class="property">Control Type: <code>Text</code></span>
+        <span class="property">Control Type: <code>Group</code></span>
       </td>
     </tr>
     <tr>
@@ -4229,7 +4230,7 @@
     <tr>
       <th><abbr title="User Interface Automation">UIA</abbr></th>
       <td>
-        <span class="property">Control Type: <code>Text</code></span><br>
+        <span class="property">Control Type: <code>Group</code></span><br>
         <span class="property">Localized Control Type: <code>term</code></span>
       </td>
     </tr>


### PR DESCRIPTION
closes #220

updates paragraph and heading mappings to match reality.

updates other uia control type mappings to move away from text, as these roles will often contain more than text leaf nodes.

other roles could be added to this PR, but will make those updates after discussion with the wg.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/pull/221.html" title="Last updated on Feb 7, 2024, 1:41 PM UTC (45ac4e0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/221/da44641...45ac4e0.html" title="Last updated on Feb 7, 2024, 1:41 PM UTC (45ac4e0)">Diff</a>