### PR TITLE
feat: add aria-actions mapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -4689,6 +4689,45 @@
       <p>There are a number of occurrences in the table where a given state or property is declared "Not mapped".  In some cases, this occurs for the default value of the state/property, and is equivalent to its absence.  User agents might find it quicker to map the value than check to see if it is the default. For computational efficiency, user agents MAY expose the state or property value if doing so is equivalent to not mapping it.  These cases are marked with an asterisk.  </p>
       <p>In other cases, it is mandatory that the state/property not be mapped, since exposing it implies a related affordance.  An example is <a class="state-reference" href="#aria-grabbed"><code>aria-grabbed</code></a>.  Its absence not only indicates that the accessible object is not grabbed, but further defines it as not grab-able.  These cases are marked as "Not mapped" without an asterisk.  </p> 
     </section>
+<h4 id=ariaActions><code>aria-actions</code></h4>
+<table aria-labelledby=ariaActions>
+  <tbody>
+    <tr>
+      <th>ARIA Specification</th>
+      <td>
+        <a class="property-reference" href="#aria-actions"><code>aria-actions</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 </th>
+      <td>
+        <span class="relation">Relation: <code>IA2_RELATION_DETAILS</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br>
+        <span class="relation">Reverse Relation: <code>IA2_RELATION_DETAILS_FOR</code> points to element</span><br>
+        <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr></th>
+      <td>
+        <span class="property">Property: <code>DescribedBy</code>: points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+      <td>
+        <span class="relation">Relation: <code>RELATION_DETAILS</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br>
+        <span class="relation">Reverse Relation: <code>RELATION_DETAILS_FOR</code> points to element</span><br>
+        <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+      <td>
+        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+      </td>
+    </tr>
+  </tbody>
+</table>
 <h4 id=ariaActiveDescendant><code>aria-activedescendant</code></h4>
 <table aria-labelledby=ariaActiveDescendant>
   <tbody>


### PR DESCRIPTION
Part of the work on https://github.com/w3c/aria/issues/1440

<!--- IF EDITORIAL or CHORE, delete the rest of this template -->

This adds mappings for `aria-actions` that piggyback off `aria-details`. This should (in theory) allow actions to build off the work already done for `aria-details` while still making it possible for screen reader vendors to create different UX for actions.

# Implementation

* WPT tests:
* Implementations (link to issue or when done, link to commit):
   * WebKit:
   * Gecko:
   * Blink:
