### PR TITLE
Update UIA alert event in role mapping table to match UIA changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -382,7 +382,7 @@
         <span class="property">Control Type: <code>Group</code></span><br>
         <span class="property">Localized Control Type: <code>alert</code></span><br>
         <span class="property">LiveSetting: <code>Assertive (2)</code></span><br>
-        <span class="event">Event: The user agent SHOULD fire a system alert <a class="termref">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span>
+        <span class="event">Event: The user agent SHOULD fire a <code>LiveRegionChanged</code> <a class="termref">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Based on screen reader feedback, the `alert` role no longer fires a system alert event, but a live region changed event (still on insertion).

Related Chromium PR with the change: https://chromium-review.googlesource.com/c/chromium/src/+/3715513


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/pull/229.html" title="Last updated on Apr 25, 2024, 9:02 PM UTC (8e6d222)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/core-aam/229/db60fd5...8e6d222.html" title="Last updated on Apr 25, 2024, 9:02 PM UTC (8e6d222)">Diff</a>